### PR TITLE
Preload template files to improve performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 *.user
 .idea/
 *.log
+tests/
 cmake-build-debug/

--- a/main.cpp
+++ b/main.cpp
@@ -39,19 +39,23 @@ int main(int ac, const char* av[]) {
     bool enable_autorefresh_option {*enable_autorefresh_option_opt};
     bool enable_output_key_checker {*enable_output_key_checker_opt};
 
-    auto port_opt           = opts.get_option<string>("port");
-    auto bc_path_opt        = opts.get_option<string>("bc-path");
-    auto custom_db_path_opt = opts.get_option<string>("custom-db-path");
-    auto deamon_url_opt     = opts.get_option<string>("deamon-url");
-    auto ssl_crt_file_opt   = opts.get_option<string>("ssl-crt-file");
-    auto ssl_key_file_opt   = opts.get_option<string>("ssl-key-file");
+    auto port_opt               = opts.get_option<string>("port");
+    auto bc_path_opt            = opts.get_option<string>("bc-path");
+    auto custom_db_path_opt     = opts.get_option<string>("custom-db-path");
+    auto deamon_url_opt         = opts.get_option<string>("deamon-url");
+    auto ssl_crt_file_opt       = opts.get_option<string>("ssl-crt-file");
+    auto ssl_key_file_opt       = opts.get_option<string>("ssl-key-file");
+    auto no_blocks_on_index_opt = opts.get_option<string>("no-blocks-on-index");
 
     // set  monero log output level
     uint32_t log_level = 0;
     mlog_configure("", true);
 
-    //cast port number in string to uint16
+    //cast port number in string to uint
     uint16_t app_port = boost::lexical_cast<uint16_t>(*port_opt);
+
+    // cast no_blocks_on_index_opt to uint
+    uint64_t no_blocks_on_index = boost::lexical_cast<uint64_t>(*no_blocks_on_index_opt);
 
     bool use_ssl {false};
 
@@ -155,7 +159,8 @@ int main(int ac, const char* av[]) {
                           enable_pusher,
                           enable_key_image_checker,
                           enable_output_key_checker,
-                          enable_autorefresh_option);
+                          enable_autorefresh_option,
+                          no_blocks_on_index);
 
     // crow instance
     crow::SimpleApp app;

--- a/src/CmdLineOptions.cpp
+++ b/src/CmdLineOptions.cpp
@@ -35,6 +35,8 @@ namespace xmreg
                  "enable users to have the index page on autorefresh")
                 ("port,p", value<string>()->default_value("8081"),
                  "default port")
+                ("no-blocks-on-index", value<string>()->default_value("10"),
+                 "number of last blocks to be shown on index page")
                 ("bc-path,b", value<string>(),
                  "path to lmdb blockchain")
                 ("ssl-crt-file", value<string>(),

--- a/src/page.h
+++ b/src/page.h
@@ -564,8 +564,6 @@ public:
             pair<uint64_t, uint64_t> sum_outputs = xmreg::sum_money_in_outputs(_tx_info.tx_json);
             uint64_t num_nonrct_inputs = xmreg::count_nonrct_inputs(_tx_info.tx_json);
 
-            sum_money_in_outputs(_tx_info.tx_json);
-
             // get mixin number in each transaction
             vector<uint64_t> mixin_numbers = xmreg::get_mixin_no(_tx_info.tx_json);
 

--- a/src/page.h
+++ b/src/page.h
@@ -557,29 +557,34 @@ public:
                                          delta_time[3], delta_time[4]);
             }
 
-            //cout << _tx_info.tx_json << endl;
-
             // sum xmr in inputs and ouputs in the given tx
-            pair<uint64_t, uint64_t> sum_inputs  = xmreg::sum_money_in_inputs(_tx_info.tx_json);
-            pair<uint64_t, uint64_t> sum_outputs = xmreg::sum_money_in_outputs(_tx_info.tx_json);
-            uint64_t num_nonrct_inputs = xmreg::count_nonrct_inputs(_tx_info.tx_json);
+            pair<uint64_t, uint64_t> sum_inputs;
+            pair<uint64_t, uint64_t> sum_outputs;
+            uint64_t num_nonrct_inputs;
 
             // get mixin number in each transaction
-            vector<uint64_t> mixin_numbers = xmreg::get_mixin_no(_tx_info.tx_json);
+            vector<uint64_t> mixin_numbers;
 
-            uint64_t mixin_no = 0;
-
-            if (!mixin_numbers.empty())
-                mixin_no = mixin_numbers.at(0) - 1;
-
-            json j_tx;
+            uint64_t mixin_no {0};
 
             string is_ringct_str  {"N/A"};
             string rct_type_str   {"N/A"};
 
             try
             {
+                json j_tx;
+
                 j_tx = json::parse(_tx_info.tx_json);
+
+                // sum xmr in inputs and ouputs in the given tx
+                sum_inputs        = xmreg::sum_money_in_inputs(j_tx);
+                sum_outputs       = xmreg::sum_money_in_outputs(j_tx);
+                num_nonrct_inputs = xmreg::count_nonrct_inputs(j_tx);
+                mixin_numbers     = xmreg::get_mixin_no(j_tx);
+
+                if (!mixin_numbers.empty())
+                    mixin_no = mixin_numbers.at(0) - 1;
+
 
                 if (j_tx["version"].get<size_t>() > 1)
                 {

--- a/src/page.h
+++ b/src/page.h
@@ -253,8 +253,6 @@ class page {
 
     string lmdb2_path;
 
-    string css_styles;
-
     bool testnet;
 
     bool enable_pusher;
@@ -300,7 +298,7 @@ public:
               enable_autorefresh_option {_enable_autorefresh_option},
               no_blocks_on_index {_no_blocks_on_index}
     {
-        css_styles = xmreg::read(TMPL_CSS_STYLES);
+
         no_of_mempool_tx_of_frontpage = 25;
 
         // just moneky patching now, to check
@@ -335,11 +333,24 @@ public:
         // read template files for all the pages
         // into template_file map
 
-        template_file["header"]       = xmreg::read(TMPL_HEADER);
-        template_file["footer"]       = get_footer();
-        template_file["index2"]       = get_full_page(xmreg::read(TMPL_INDEX2));
-        template_file["mempool"]      = xmreg::read(TMPL_MEMPOOL);
-        template_file["mempool_full"] = get_full_page(template_file["mempool"]);
+        template_file["css_styles"]      = xmreg::read(TMPL_CSS_STYLES);
+        template_file["header"]          = xmreg::read(TMPL_HEADER);
+        template_file["footer"]          = get_footer();
+        template_file["index2"]          = get_full_page(xmreg::read(TMPL_INDEX2));
+        template_file["mempool"]         = xmreg::read(TMPL_MEMPOOL);
+        template_file["mempool_full"]    = get_full_page(template_file["mempool"]);
+        template_file["block"]           = get_full_page(xmreg::read(TMPL_BLOCK));
+        template_file["tx"]              = get_full_page(xmreg::read(TMPL_TX));
+        template_file["my_outputs"]      = get_full_page(xmreg::read(TMPL_MY_OUTPUTS));
+        template_file["rawtx"]           = get_full_page(xmreg::read(TMPL_MY_RAWTX));
+        template_file["checkrawtx"]      = get_full_page(xmreg::read(TMPL_MY_CHECKRAWTX));
+        template_file["pushrawtx"]       = get_full_page(xmreg::read(TMPL_MY_PUSHRAWTX));
+        template_file["rawkeyimgs"]      = get_full_page(xmreg::read(TMPL_MY_RAWKEYIMGS));
+        template_file["rawoutputkeys"]   = get_full_page(xmreg::read(TMPL_MY_RAWOUTPUTKEYS));
+        template_file["checkrawkeyimgs"] = get_full_page(xmreg::read(TMPL_MY_CHECKRAWKEYIMGS));
+        template_file["checkoutputkeys"] = get_full_page(xmreg::read(TMPL_MY_CHECKRAWOUTPUTKEYS));
+        template_file["address"]         = get_full_page(xmreg::read(TMPL_ADDRESS));
+        template_file["search_results"]  = get_full_page(xmreg::read(TMPL_SEARCH_RESULTS));
 
     }
 
@@ -848,16 +859,10 @@ public:
         context["blk_reward"]
                 = xmreg::xmr_amount_to_str(txd_coinbase.xmr_outputs - sum_fees, "{:0.6f}");
 
-        // read block.html
-        string block_html = xmreg::read(TMPL_BLOCK);
-
         add_css_style(context);
 
-        // add header and footer
-        string full_page = get_full_page(block_html);
-
         // render the page
-        return mstch::render(full_page, context);
+        return mstch::render(template_file["block"], context);
     }
 
 
@@ -1649,20 +1654,10 @@ public:
         context["possible_spending"] = xmreg::xmr_amount_to_str(
                 possible_spending, "{:0.12f}", false);
 
-
-        //cout << "no_of_matched_mixins: " << no_of_matched_mixins << endl;
-
-
-        // read my_outputs.html
-        string my_outputs_html = xmreg::read(TMPL_MY_OUTPUTS);
-
-        // add header and footer
-        string full_page = get_full_page(my_outputs_html);
-
         add_css_style(context);
 
         // render the page
-        return mstch::render(full_page, context);
+        return mstch::render(template_file["my_outputs"], context);
     }
 
     string
@@ -1686,16 +1681,10 @@ public:
                 {"have_custom_lmdb"     , have_custom_lmdb}
         };
 
-        // read rawtx.html
-        string rawtx_html = xmreg::read(TMPL_MY_RAWTX);
-
-        // add header and footer
-        string full_page = get_full_page(rawtx_html);
-
         add_css_style(context);
 
         // render the page
-        return mstch::render(full_page, context);
+        return mstch::render(template_file["rawtx"], context);
     }
 
     string
@@ -2319,17 +2308,10 @@ public:
                 {"tx_details", xmreg::read(string(TMPL_PARIALS_DIR) + "/tx_details.html")},
         };
 
-
-        // read checkrawtx.html
-        string checkrawtx_html = xmreg::read(TMPL_MY_CHECKRAWTX);
-
-        // add header and footer
-        string full_page = get_full_page(checkrawtx_html);
-
         add_css_style(context);
 
         // render the page
-        return mstch::render(full_page, context, partials);
+        return mstch::render(template_file["checkrawtx"], context, partials);
     }
 
     string
@@ -2354,11 +2336,8 @@ public:
         };
         context.emplace("txs", mstch::array{});
 
-        // read pushrawtx.html
-        string pushrawtx_html = xmreg::read(TMPL_MY_PUSHRAWTX);
-
         // add header and footer
-        string full_page = get_full_page(pushrawtx_html);
+        string full_page = template_file["pushrawtx"];
 
         add_css_style(context);
 
@@ -2532,16 +2511,10 @@ public:
                 {"have_custom_lmdb"   , have_custom_lmdb}
         };
 
-        // read rawkeyimgs.html
-        string rawkeyimgs_html = xmreg::read(TMPL_MY_RAWKEYIMGS);
-
-        // add header and footer
-        string full_page = get_full_page(rawkeyimgs_html);
-
         add_css_style(context);
 
         // render the page
-        return mstch::render(full_page, context);
+        return mstch::render(template_file["rawkeyimgs"], context);
     }
 
     string
@@ -2553,16 +2526,10 @@ public:
                 {"have_custom_lmdb"   , have_custom_lmdb}
         };
 
-        // read rawoutputkeys.html
-        string rawoutputkeys_html = xmreg::read(TMPL_MY_RAWOUTPUTKEYS);
-
-        // add header and footer
-        string full_page = get_full_page(rawoutputkeys_html);
-
         add_css_style(context);
 
         // render the page
-        return mstch::render(full_page, context);
+        return mstch::render(template_file["rawoutputkeys"], context);
     }
 
     string
@@ -2585,11 +2552,8 @@ public:
                 {"error_msg"       , string{}},
         };
 
-        // read page template
-        string checkrawkeyimgs_html = xmreg::read(TMPL_MY_CHECKRAWKEYIMGS);
-
         // add header and footer
-        string full_page = get_full_page(checkrawkeyimgs_html);
+        string full_page = template_file["checkrawkeyimgs"];
 
         add_css_style(context);
 
@@ -2948,12 +2912,8 @@ public:
                 {"error_msg"       , string{}}
         };
 
-
-        // read page template
-        string checkoutputkeys_html = xmreg::read(TMPL_MY_CHECKRAWOUTPUTKEYS);
-
         // add header and footer
-        string full_page = get_full_page(checkoutputkeys_html);
+        string full_page = template_file["checkoutputkeys"];
 
         add_css_style(context);
 
@@ -3712,16 +3672,10 @@ public:
                 {"have_custom_lmdb"   , have_custom_lmdb}
         };
 
-        // read address.html
-        string address_html = xmreg::read(TMPL_ADDRESS);
-
-        // add header and footer
-        string full_page = get_full_page(address_html);
-
         add_css_style(context);
 
         // render the page
-        return mstch::render(full_page, context);
+        return mstch::render(template_file["address"], context);
     }
 
     // ;
@@ -3746,16 +3700,10 @@ public:
                 {"have_custom_lmdb"     , have_custom_lmdb}
         };
 
-        // read address.html
-        string address_html = xmreg::read(TMPL_ADDRESS);
-
         add_css_style(context);
 
-        // add header and footer
-        string full_page = get_full_page(address_html);
-
         // render the page
-        return mstch::render(full_page, context);
+        return mstch::render(template_file["address"], context);
     }
 
     map<string, vector<string>>
@@ -3957,11 +3905,8 @@ public:
             }
         }
 
-        // read search_results.html
-        string search_results_html = xmreg::read(TMPL_SEARCH_RESULTS);
-
         // add header and footer
-        string full_page = get_full_page(search_results_html);
+        string full_page = template_file["search_results"];
 
         // read partial for showing details of tx(s) found
         map<string, string> partials {
@@ -4728,7 +4673,7 @@ private:
     add_css_style(mstch::map& context)
     {
         context["css_styles"] = mstch::lambda{[&](const std::string& text) -> mstch::node {
-            return this->css_styles;
+            return template_file["css_styles"];
         }};
     }
 

--- a/src/page.h
+++ b/src/page.h
@@ -270,6 +270,13 @@ class page {
     uint64_t no_of_mempool_tx_of_frontpage;
     uint64_t no_blocks_on_index;
 
+    // instead of constatnly reading template files
+    // from hard drive for each request, we can read
+    // them only once, when the explorer starts into this map
+    // this will improve performance of the explorer and reduce
+    // read operation in OS
+    map<string, string> template_file;
+
 
 public:
 
@@ -323,6 +330,16 @@ public:
                     "Just some searches wont be possible"
                  << endl;
         }
+
+
+        // read template files for all the pages
+        // into template_file map
+
+        template_file["header"]       = xmreg::read(TMPL_HEADER);
+        template_file["footer"]       = get_footer();
+        template_file["index2"]       = get_full_page(xmreg::read(TMPL_INDEX2));
+        template_file["mempool"]      = xmreg::read(TMPL_MEMPOOL);
+        template_file["mempool_full"] = get_full_page(template_file["mempool"]);
 
     }
 
@@ -494,16 +511,10 @@ public:
         // append mempool_html to the index context map
         context["mempool_info"] = mempool_html;
 
-        // read index.html
-        string index2_html = xmreg::read(TMPL_INDEX2);
-
-        // add header and footer
-        string full_page = get_full_page(index2_html);
-
         add_css_style(context);
 
         // render the page
-        return mstch::render(full_page, context);
+        return mstch::render(template_file["index2"], context);
 
     }
 
@@ -640,8 +651,6 @@ public:
             return t1 > t2;
         });
 
-        // read mempool.html
-        string mempool_html = xmreg::read(TMPL_MEMPOOL);
 
         if (add_header_and_footer)
         {
@@ -650,11 +659,8 @@ public:
 
             context["partial_mempool_shown"] = false;
 
-            // add header and footer
-            string full_page = get_full_page(mempool_html);
-
             // render the page
-            return mstch::render(full_page, context);
+            return mstch::render(template_file["mempool_full"], context);
         }
 
         // this is for partial disply on front page.
@@ -672,7 +678,7 @@ public:
         context["partial_mempool_shown"] = true;
 
         // render the page
-        return mstch::render(mempool_html, context);
+        return mstch::render(template_file["mempool"], context);
     }
 
 
@@ -4695,11 +4701,11 @@ private:
 
 
     string
-    get_full_page(string& middle)
+    get_full_page(const string& middle)
     {
-        return xmreg::read(TMPL_HEADER)
+        return template_file["header"]
                + middle
-               + get_footer();
+               + template_file["footer"];
     }
 
     string

--- a/src/page.h
+++ b/src/page.h
@@ -275,13 +275,6 @@ class page {
     // read operation in OS
     map<string, string> template_file;
 
-    // instead of constatnly reading template files
-    // from hard drive for each request, we can read
-    // them only once, when the explorer starts into this map
-    // this will improve performance of the explorer and reduce
-    // read operation in OS
-    map<string, string> template_file;
-
 
 public:
 

--- a/src/page.h
+++ b/src/page.h
@@ -268,6 +268,7 @@ class page {
 
 
     uint64_t no_of_mempool_tx_of_frontpage;
+    uint64_t no_blocks_on_index;
 
 
 public:
@@ -277,7 +278,8 @@ public:
          bool _testnet, bool _enable_pusher,
          bool _enable_key_image_checker,
          bool _enable_output_key_checker,
-         bool _enable_autorefresh_option)
+         bool _enable_autorefresh_option,
+         uint64_t _no_blocks_on_index)
             : mcore {_mcore},
               core_storage {_core_storage},
               rpc {_deamon_url},
@@ -288,7 +290,8 @@ public:
               have_custom_lmdb {false},
               enable_key_image_checker {_enable_key_image_checker},
               enable_output_key_checker {_enable_output_key_checker},
-              enable_autorefresh_option {_enable_autorefresh_option}
+              enable_autorefresh_option {_enable_autorefresh_option},
+              no_blocks_on_index {_no_blocks_on_index}
     {
         css_styles = xmreg::read(TMPL_CSS_STYLES);
         no_of_mempool_tx_of_frontpage = 25;
@@ -336,24 +339,25 @@ public:
         server_timestamp = std::time(nullptr);
 
         // number of last blocks to show
-        uint64_t no_of_last_blocks {25 + 1};
+        uint64_t no_of_last_blocks {no_blocks_on_index + 1};
 
         // get the current blockchain height. Just to check
         uint64_t height = core_storage->get_current_blockchain_height();
 
         // initalise page tempate map with basic info about blockchain
         mstch::map context {
-                {"testnet"         , testnet},
-                {"have_custom_lmdb", have_custom_lmdb},
-                {"refresh"         , refresh_page},
-                {"height"          , std::to_string(height)},
-                {"server_timestamp", xmreg::timestamp_to_str(server_timestamp)},
-                {"age_format"      , string("[h:m:d]")},
-                {"page_no"         , std::to_string(page_no)},
-                {"total_page_no"   , std::to_string(height / (no_of_last_blocks))},
-                {"is_page_zero"    , !bool(page_no)},
-                {"next_page"       , std::to_string(page_no + 1)},
-                {"prev_page"       , std::to_string((page_no > 0 ? page_no - 1 : 0))},
+                {"testnet"          , testnet},
+                {"have_custom_lmdb" , have_custom_lmdb},
+                {"refresh"          , refresh_page},
+                {"height"           , std::to_string(height)},
+                {"server_timestamp" , xmreg::timestamp_to_str(server_timestamp)},
+                {"age_format"       , string("[h:m:d]")},
+                {"page_no"          , std::to_string(page_no)},
+                {"total_page_no"    , std::to_string(height / (no_of_last_blocks))},
+                {"is_page_zero"     , !bool(page_no)},
+                {"no_of_last_blocks", no_of_last_blocks},
+                {"next_page"        , std::to_string(page_no + 1)},
+                {"prev_page"        , std::to_string((page_no > 0 ? page_no - 1 : 0))},
                 {"enable_pusher"            , enable_pusher},
                 {"enable_key_image_checker" , enable_key_image_checker},
                 {"enable_output_key_checker", enable_output_key_checker},

--- a/src/templates/index2.html
+++ b/src/templates/index2.html
@@ -31,7 +31,7 @@
     {{{mempool_info}}}
 
     {{#is_page_zero}}
-      <h2 style="margin-bottom: 0px">Transactions in the last 25 blocks</h2>
+      <h2 style="margin-bottom: 0px">Transactions in the last {{no_of_last_blocks}} blocks</h2>
     {{/is_page_zero}}
     {{^is_page_zero}}
       <h2 style="margin-bottom: 0px">Transactions in older blocks<!--(height: {{height}})--></h2>

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -1388,7 +1388,22 @@ get_human_readable_timestamp(uint64_t ts)
     return std::string(buffer);
 }
 
+void
+pause_execution(uint64_t no_seconds, const string& text)
+{
 
+    cout << "\nPausing " << text
+         << " for " << no_seconds << " seconds: "
+         << flush;
+
+    for (size_t i = 0; i < no_seconds; ++i)
+    {
+        cout << "." << flush;
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    cout << endl;
+}
 
 }
 

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -343,7 +343,19 @@ sum_money_in_outputs(const string& json_str)
     return sum_xmr;
 };
 
+pair<uint64_t, uint64_t>
+sum_money_in_outputs(const json& _json)
+{
+    pair<uint64_t, uint64_t> sum_xmr {0ULL, 0ULL};
 
+    for (const json& vout: _json["vout"])
+    {
+        sum_xmr.first += vout["amount"].get<uint64_t>();
+        ++sum_xmr.second;
+    }
+
+    return sum_xmr;
+};
 
 uint64_t
 sum_money_in_inputs(const transaction& tx)
@@ -395,6 +407,21 @@ sum_money_in_inputs(const string& json_str)
     return sum_xmr;
 };
 
+
+pair<uint64_t, uint64_t>
+sum_money_in_inputs(const json& _json)
+{
+    pair<uint64_t, uint64_t> sum_xmr {0, 0};
+
+    for (const json& vin: _json["vin"])
+    {
+        sum_xmr.first += vin["key"]["amount"].get<uint64_t>();
+        ++sum_xmr.second;
+    }
+
+    return sum_xmr;
+};
+
 uint64_t
 count_nonrct_inputs(const transaction& tx)
 {
@@ -438,6 +465,22 @@ count_nonrct_inputs(const string& json_str)
     }
 
     for (json& vin: j["vin"])
+    {
+        uint64_t amount = vin["key"]["amount"].get<uint64_t>();
+        if (amount != 0)
+            ++num;
+    }
+
+    return num;
+};
+
+
+uint64_t
+count_nonrct_inputs(const json& _json)
+{
+    uint64_t num {0};
+
+    for (const json& vin: _json["vin"])
     {
         uint64_t amount = vin["key"]["amount"].get<uint64_t>();
         if (amount != 0)
@@ -586,6 +629,16 @@ get_mixin_no(const string& json_str)
         cerr << "get_mixin_no: " << e.what() << endl;
         return mixin_no;
     }
+
+    return mixin_no;
+}
+
+vector<uint64_t>
+get_mixin_no(const json& _json)
+{
+    vector<uint64_t> mixin_no;
+
+    mixin_no.push_back(_json["vin"].at(0)["key"]["key_offsets"].size());
 
     return mixin_no;
 }

--- a/src/tools.h
+++ b/src/tools.h
@@ -333,6 +333,9 @@ calc_median(It it_begin, It it_end)
 }
 
 
+void
+pause_execution(uint64_t no_seconds, const string& text = "now");
+
 }
 
 #endif //XMREG01_TOOLS_H

--- a/src/tools.h
+++ b/src/tools.h
@@ -133,17 +133,26 @@ sum_money_in_outputs(const transaction& tx);
 pair<uint64_t, uint64_t>
 sum_money_in_outputs(const string& json_str);
 
+pair<uint64_t, uint64_t>
+sum_money_in_outputs(const json& _json);
+
 uint64_t
 sum_money_in_inputs(const transaction& tx);
 
 pair<uint64_t, uint64_t>
 sum_money_in_inputs(const string& json_str);
 
+pair<uint64_t, uint64_t>
+sum_money_in_inputs(const json& _json);
+
 uint64_t
 count_nonrct_inputs(const transaction& tx);
 
 uint64_t
 count_nonrct_inputs(const string& json_str);
+
+uint64_t
+count_nonrct_inputs(const json& _json);
 
 array<uint64_t, 2>
 sum_money_in_tx(const transaction& tx);
@@ -159,6 +168,9 @@ get_mixin_no(const transaction& tx);
 
 vector<uint64_t>
 get_mixin_no(const string& json_str);
+
+vector<uint64_t>
+get_mixin_no(const json& _json);
 
 vector<uint64_t>
 get_mixin_no_in_txs(const vector<transaction>& txs);


### PR DESCRIPTION
Currently html template files are read from hdd for each request. This can be slow. So we preload all templates now into template_file map when xmrblocks starts. No more constant reading template files from hdd.