### PR TITLE
build on mac and windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin" OR WIN32)
     add_library(unbound STATIC IMPORTED)
-    set_property(TARGET unbound PROPERTY IMPORTED_LOCATION ${MONERO_LIBS_DIR}/libunbound.a)
+    set_property(TARGET unbound PROPERTY IMPORTED_LOCATION ${MONERO_BUILD_DIR}/external/unbound/libunbound.a)
 endif()
 
 # include boost headers
@@ -107,13 +107,19 @@ set(LIBRARIES
         common
         mnemonics
         epee
+        easylogging
         ${Boost_LIBRARIES}
         pthread
         unbound
         curl
         crypto
-        atomic
         ssl)
+
+if(APPLE)
+    set(LIBRARIES ${LIBRARIES} "-framework IOKit")
+else()
+    set(LIBRARIES ${LIBRARIES} atomic)
+endif()
 
 if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT WIN32)
     set(LIBRARIES ${LIBRARIES} unwind)

--- a/cmake/FindMonero.cmake
+++ b/cmake/FindMonero.cmake
@@ -58,15 +58,10 @@ foreach (l ${LIBS})
 endforeach()
 
 
-if (EXISTS ${MONERO_BUILD_DIR}/external/unbound/libunbound.a)
-	add_library(unbound STATIC IMPORTED)
-	set_property(TARGET unbound PROPERTY IMPORTED_LOCATION ${MONERO_BUILD_DIR}/external/unbound/libunbound.a)
-endif()
-
-if (EXISTS ${MONERO_BUILD_DIR}/src/crypto/libcrypto.a)
+if (EXISTS ${MONERO_BUILD_DIR}/src/crypto/libcncrypto.a)
 	add_library(cryptoxmr STATIC IMPORTED)
 	set_property(TARGET cryptoxmr
-			PROPERTY IMPORTED_LOCATION ${MONERO_BUILD_DIR}/src/crypto/libcrypto.a)
+			PROPERTY IMPORTED_LOCATION ${MONERO_BUILD_DIR}/src/crypto/libcncrypto.a)
 endif()
 
 if (EXISTS ${MONERO_BUILD_DIR}/external/easylogging++/libeasylogging.a)

--- a/ext/mstch/include/mstch/mstch.hpp
+++ b/ext/mstch/include/mstch/mstch.hpp
@@ -91,17 +91,32 @@ class lambda_t {
   std::function<std::string(node_renderer<N> renderer, const std::string&)> fun;
 };
 
+template <class Key, class Value>
+struct map : public std::map<Key, Value>
+{
+  map() {}
+  map(const map<Key, Value>& rhs) : std::map<Key, Value>(rhs) {}
+  map(const std::initializer_list<typename std::map<Key, Value>::value_type>& args) : std::map<Key, Value>(args) {}
+  map& operator=(const map& rhs)
+  {
+    std::map<Key, Value>::clear();
+    for (auto& i : rhs)
+      std::map<Key, Value>::insert(i);
+    return *this;
+  }
+};
+
 }
 
 using node = boost::make_recursive_variant<
     std::nullptr_t, std::string, int, double, bool, uint64_t, int64_t, uint32_t,
     internal::lambda_t<boost::recursive_variant_>,
     std::shared_ptr<internal::object_t<boost::recursive_variant_>>,
-    std::map<const std::string, boost::recursive_variant_>,
+    internal::map<const std::string, boost::recursive_variant_>,
     std::vector<boost::recursive_variant_>>::type;
 using object = internal::object_t<node>;
 using lambda = internal::lambda_t<node>;
-using map = std::map<const std::string, node>;
+using map = internal::map<const std::string, node>;
 using array = std::vector<node>;
 
 std::string render(

--- a/src/page.h
+++ b/src/page.h
@@ -174,7 +174,7 @@ namespace xmreg
                     {"no_nonrct_inputs"  , num_nonrct_inputs},
                     {"mixin"             , mixin_str},
                     {"blk_height"        , blk_height},
-                    {"version"           , version},
+                    {"version"           , static_cast<uint64_t>(version)},
                     {"has_payment_id"    , payment_id  != null_hash},
                     {"has_payment_id8"   , payment_id8 != null_hash8},
                     {"payment_id"        , pod_to_hex(payment_id)},
@@ -902,7 +902,7 @@ namespace xmreg
 
             // initalise page tempate map with basic info about mempool
             mstch::map context {
-                    {"mempool_size"          , mempool_txs.size()},
+                    {"mempool_size"          , static_cast<uint64_t>(mempool_txs.size())},
                     {"show_cache_times"      , show_cache_times}
             };
 
@@ -1412,7 +1412,7 @@ namespace xmreg
 
             mstch::map tx_context;
 
-            if (enable_tx_cache && tx_context_cache.Contains({tx_hash, with_ring_signatures}))
+            if (enable_tx_cache && tx_context_cache.Contains({tx_hash, static_cast<bool>(with_ring_signatures)}))
             {
                 // with_ring_signatures == 0 means that cache is not used
                 // when obtaining detailed information about tx is requested.
@@ -1422,7 +1422,7 @@ namespace xmreg
                 auto start = std::chrono::steady_clock::now();
 
                 const tx_info_cache& tx_info_cashed
-                        = tx_context_cache.Get({tx_hash, with_ring_signatures});
+                        = tx_context_cache.Get({tx_hash, static_cast<bool>(with_ring_signatures)});
 
                 tx_context = tx_info_cashed.tx_map;
 
@@ -1476,10 +1476,10 @@ namespace xmreg
                         // its not in blockchain, but it was there when we cashed it.
                         // so we update it in cash, as it should be back in mempool
 
-                        tx_context = construct_tx_context(tx, with_ring_signatures);
+                        tx_context = construct_tx_context(tx, static_cast<bool>(with_ring_signatures));
 
                         tx_context_cache.Put(
-                                {tx_hash, with_ring_signatures},
+                                {tx_hash, static_cast<bool>(with_ring_signatures)},
                                 tx_info_cache {
                                         boost::get<uint64_t>(tx_context["tx_blk_height"]),
                                         boost::get<uint64_t>(tx_context["blk_timestamp_uint"]),
@@ -1498,10 +1498,10 @@ namespace xmreg
                         // checking if in blockchain already
                         // it was before in mempool, but now maybe already in blockchain
 
-                        tx_context = construct_tx_context(tx, with_ring_signatures);
+                        tx_context = construct_tx_context(tx, static_cast<bool>(with_ring_signatures));
 
                         tx_context_cache.Put(
-                                {tx_hash, with_ring_signatures},
+                                {tx_hash, static_cast<bool>(with_ring_signatures)},
                                 tx_info_cache {
                                         boost::get<uint64_t>(tx_context["tx_blk_height"]),
                                         boost::get<uint64_t>(tx_context["blk_timestamp_uint"]),
@@ -1535,7 +1535,7 @@ namespace xmreg
                 // tx context. just for fun, to see if cache is any faster.
                 auto start = std::chrono::steady_clock::now();
 
-                tx_context = construct_tx_context(tx, with_ring_signatures);
+                tx_context = construct_tx_context(tx, static_cast<bool>(with_ring_signatures));
 
                 auto duration = std::chrono::duration_cast<std::chrono::microseconds>
                         (std::chrono::steady_clock::now() - start);
@@ -1543,7 +1543,7 @@ namespace xmreg
                 if (enable_tx_cache)
                 {
                     tx_context_cache.Put(
-                            {tx_hash, with_ring_signatures},
+                            {tx_hash, static_cast<bool>(with_ring_signatures)},
                             tx_info_cache {
                                     boost::get<uint64_t>(tx_context["tx_blk_height"]),
                                     boost::get<uint64_t>(tx_context["blk_timestamp_uint"]),
@@ -5124,7 +5124,7 @@ namespace xmreg
                     {"tx_size"               , fmt::format("{:0.4f}",
                                                            static_cast<double>(txd.size) / 1024.0)},
                     {"tx_fee"                , xmreg::xmr_amount_to_str(txd.fee)},
-                    {"tx_version"            , txd.version},
+                    {"tx_version"            , static_cast<uint64_t>(txd.version)},
                     {"blk_timestamp"         , blk_timestamp},
                     {"blk_timestamp_uint"    , blk.timestamp},
                     {"delta_time"            , age.first},

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -4,6 +4,7 @@
 
 #include "tools.h"
 #include <codecvt>
+#include <thread>
 
 
 namespace xmreg


### PR DESCRIPTION
It's been a while since the last time I tried to build the code on Mac and Windows. The changes are:

- fixed some library paths in CMakeLists.txt
- added back linking to easylogging (Otherwise the linker on Mac/Win complains. This also doesn't seem to cause any problem for Linux. Why was this removed previously?)
- explicit cast to `uint64_t` and `bool` for `mstch::map`
- wrap `std::map<const string, mtsch::node>` with an internal class template which defines a custom `operator=()`, since the original one `std::map::oeprator=()` somehow caused a very complicated compile error