### PR TITLE
tx-pusher: support hex string of raw tx

### DIFF
--- a/src/page.h
+++ b/src/page.h
@@ -813,7 +813,7 @@ namespace xmreg
             {
                 // get only first no_of_mempool_tx txs
                 mempool_txs = MempoolStatus::get_mempool_txs(no_of_mempool_tx);
-                no_of_mempool_tx = std::min(no_of_mempool_tx, mempool_txs.size());
+                no_of_mempool_tx = std::min<uint64_t>(no_of_mempool_tx, mempool_txs.size());
             }
 
             // total size of mempool in bytes
@@ -940,7 +940,7 @@ namespace xmreg
                 cerr << "rpc.get_alt_blocks(atl_blks_hashes) failed" << endl;
             }
 
-            context.emplace("no_alt_blocks", atl_blks_hashes.size());
+            context.emplace("no_alt_blocks", (uint64_t)atl_blks_hashes.size());
 
             for (const string& alt_blk_hash: atl_blks_hashes)
             {
@@ -2769,84 +2769,101 @@ namespace xmreg
         {
             clean_post_data(raw_tx_data);
 
-            string decoded_raw_tx_data = epee::string_encoding::base64_decode(raw_tx_data);
-
-            const size_t magiclen = strlen(SIGNED_TX_PREFIX);
-
-            string data_prefix = xmreg::make_printable(decoded_raw_tx_data.substr(0, magiclen));
-
             // initalize page template context map
             mstch::map context {
                     {"testnet"              , testnet},
                     {"have_raw_tx"          , true},
                     {"has_error"            , false},
                     {"error_msg"            , string {}},
-                    {"data_prefix"          , data_prefix},
             };
-            context.emplace("txs", mstch::array{});
 
             // add header and footer
             string full_page = template_file["pushrawtx"];
 
             add_css_style(context);
 
-            if (strncmp(decoded_raw_tx_data.c_str(), SIGNED_TX_PREFIX, magiclen) != 0)
+            std::vector<tools::wallet2::pending_tx> ptx_vector;
+
+            // first try reading raw_tx_data as a raw hex string
+            std::string tx_blob;
+            cryptonote::transaction parsed_tx;
+            crypto::hash parsed_tx_hash, parsed_tx_prefixt_hash;
+            if (epee::string_tools::parse_hexstr_to_binbuff(raw_tx_data, tx_blob) && parse_and_validate_tx_from_blob(tx_blob, parsed_tx, parsed_tx_hash, parsed_tx_prefixt_hash))
             {
-                string error_msg = fmt::format("The data does not appear to be signed raw tx! Data prefix: {:s}",
-                                               data_prefix);
+                ptx_vector.push_back({});
+                ptx_vector.back().tx = parsed_tx;
+            }
+            // if failed, treat raw_tx_data as base64 encoding of signed_monero_tx
+            else
+            {
+                string decoded_raw_tx_data = epee::string_encoding::base64_decode(raw_tx_data);
 
-                context["has_error"] = true;
-                context["error_msg"] = error_msg;
+                const size_t magiclen = strlen(SIGNED_TX_PREFIX);
 
-                return mstch::render(full_page, context);
+                string data_prefix = xmreg::make_printable(decoded_raw_tx_data.substr(0, magiclen));
+
+                context["data_prefix"] = data_prefix;
+
+                if (strncmp(decoded_raw_tx_data.c_str(), SIGNED_TX_PREFIX, magiclen) != 0)
+                {
+                    string error_msg = fmt::format("The data does not appear to be signed raw tx! Data prefix: {:s}",
+                                                   data_prefix);
+
+                    context["has_error"] = true;
+                    context["error_msg"] = error_msg;
+
+                    return mstch::render(full_page, context);
+                }
+
+                if (this->enable_pusher == false)
+                {
+                    string error_msg = fmt::format(
+                            "Pushing disabled!\n "
+                                    "Run explorer with --enable-pusher flag to enable it.");
+
+                    context["has_error"] = true;
+                    context["error_msg"] = error_msg;
+
+                    return mstch::render(full_page, context);
+                }
+
+                bool r {false};
+
+                string s = decoded_raw_tx_data.substr(magiclen);
+
+                ::tools::wallet2::signed_tx_set signed_txs;
+
+                try
+                {
+                    std::istringstream iss(s);
+                    boost::archive::portable_binary_iarchive ar(iss);
+                    ar >> signed_txs;
+
+                    r = true;
+                }
+                catch (...)
+                {
+                    cerr << "Failed to parse signed tx data " << endl;
+                }
+
+
+                if (!r)
+                {
+                    string error_msg = fmt::format("Deserialization of signed tx data NOT successful! "
+                                                           "Maybe its not base64 encoded?");
+
+                    context["has_error"] = true;
+                    context["error_msg"] = error_msg;
+
+                    return mstch::render(full_page, context);
+                }
+
+                ptx_vector = signed_txs.ptx;
             }
 
-            if (this->enable_pusher == false)
-            {
-                string error_msg = fmt::format(
-                        "Pushing disabled!\n "
-                                "Run explorer with --enable-pusher flag to enable it.");
-
-                context["has_error"] = true;
-                context["error_msg"] = error_msg;
-
-                return mstch::render(full_page, context);
-            }
-
-            bool r {false};
-
-            string s = decoded_raw_tx_data.substr(magiclen);
-
-            ::tools::wallet2::signed_tx_set signed_txs;
-
-            try
-            {
-                std::istringstream iss(s);
-                boost::archive::portable_binary_iarchive ar(iss);
-                ar >> signed_txs;
-
-                r = true;
-            }
-            catch (...)
-            {
-                cerr << "Failed to parse signed tx data " << endl;
-            }
-
-
-            if (!r)
-            {
-                string error_msg = fmt::format("Deserialization of signed tx data NOT successful! "
-                                                       "Maybe its not base64 encoded?");
-
-                context["has_error"] = true;
-                context["error_msg"] = error_msg;
-
-                return mstch::render(full_page, context);
-            }
+            context.emplace("txs", mstch::array{});
 
             mstch::array& txs = boost::get<mstch::array>(context["txs"]);
-
-            std::vector<tools::wallet2::pending_tx> ptx_vector = signed_txs.ptx;
 
             // actually commit the transactions
             while (!ptx_vector.empty())
@@ -4719,7 +4736,7 @@ namespace xmreg
             }
 
             // maxium five last blocks
-            no_of_last_blocks = std::min(no_of_last_blocks, 5ul);
+            no_of_last_blocks = std::min<uint64_t>(no_of_last_blocks, 5ul);
 
             if (address_str.empty())
             {

--- a/src/templates/rawtx.html
+++ b/src/templates/rawtx.html
@@ -8,12 +8,15 @@
 
     <div class="center">
         <form action="/checkandpush" method="post" style="width:100%; margin-top:15px" class="style-1">
-            Paste base64 encoded, unsigned or signed transaction data here<br/>
+            Paste here either a hex string of raw transaction (the <tt>tx_blob</tt> response in the wallet RPC, or the <tt>raw_monero_tx</tt> file saved by the wallet CLI with <tt>--do-not-relay</tt> option specified),<br/>
+            or base64 encoded, unsigned or signed transaction data<br/>
             (In Linux, can get base64 signed raw tx data: <i>base64 signed_monero_tx | xclip -selection clipboard</i>)<br/>
             (In Windows, can get base64 signed raw tx data: <i>certutil.exe -encode -f signed_monero_tx encoded.txt & type "encoded.txt" | clip</i>)<br/>
             <textarea name="rawtxdata" rows="20" cols="80"></textarea>
             <br/>
             Note: data is sent to the server, as the calculations are done on the server side
+            <br/>
+            Note: "check" does not work for the hex string of raw transaction
             <br/>
             <input type="submit" name="action" value="check">
             &nbsp;  &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;  &nbsp; &nbsp; &nbsp; &nbsp;


### PR DESCRIPTION
This patch combined with https://github.com/monero-project/monero/pull/2586 will make it easier for CLI users to anonymously broadcast transactions to the network using this explorer running on the hidden network.