### PR TITLE
misc fixes to eliminate compiler warnings

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -392,6 +392,7 @@ main(int ac, const char* av[])
                 return xmrblocks.show_checkrawtx(raw_tx_data, action);
             else if (action == "push")
                 return xmrblocks.show_pushrawtx(raw_tx_data, action);
+            return string("Provided action is neither check nor push");
 
         });
     }

--- a/src/MempoolStatus.cpp
+++ b/src/MempoolStatus.cpp
@@ -58,7 +58,7 @@ MempoolStatus::start_mempool_status_thread()
                      else
                      {
                          cout << "Current network info read, ";
-                         loop_index == 0;
+                         loop_index = 0;
                      }
                  }
 

--- a/src/page.h
+++ b/src/page.h
@@ -3129,7 +3129,7 @@ namespace xmreg
 
             context["data_prefix"] = data_prefix;
 
-            if (!strncmp(decoded_raw_data.c_str(), KEY_IMAGE_EXPORT_FILE_MAGIC, magiclen) == 0)
+            if (strncmp(decoded_raw_data.c_str(), KEY_IMAGE_EXPORT_FILE_MAGIC, magiclen) != 0)
             {
                 string error_msg = fmt::format("This does not seem to be key image export data.");
 
@@ -3274,7 +3274,7 @@ namespace xmreg
 
             context["data_prefix"] = data_prefix;
 
-            if (!strncmp(decoded_raw_data.c_str(), OUTPUT_EXPORT_FILE_MAGIC, magiclen) == 0)
+            if (strncmp(decoded_raw_data.c_str(), OUTPUT_EXPORT_FILE_MAGIC, magiclen) != 0)
             {
                 string error_msg = fmt::format("This does not seem to be output keys export data.");
 


### PR DESCRIPTION
Fix for the following warnings:
```
~/onion-monero-blockchain-explorer/src/MempoolStatus.cpp:61:37: warning: equality comparison result unused [-Wunused-comparison]
                         loop_index == 0;
                         ~~~~~~~~~  ~~^~~~
~/onion-monero-blockchain-explorer/src/MempoolStatus.cpp:61:37: note: use '=' to turn this equality comparison into an assignment
                         loop_index == 0;
                                    ^~
                                    =
In file included from ~/onion-monero-blockchain-explorer/main.cpp:4:
~/onion-monero-blockchain-explorer/src/page.h:3132:17: warning: logical not is only applied to the left hand side of this comparison
      [-Wlogical-not-parentheses]
            if (!strncmp(decoded_raw_data.c_str(), KEY_IMAGE_EXPORT_FILE_MAGIC, magiclen) == 0)
                ^                                                                         ~~
~/onion-monero-blockchain-explorer/src/page.h:3132:17: note: add parentheses after the '!' to evaluate the comparison first
            if (!strncmp(decoded_raw_data.c_str(), KEY_IMAGE_EXPORT_FILE_MAGIC, magiclen) == 0)
                ^
                 (                                                                            )
~/onion-monero-blockchain-explorer/src/page.h:3132:17: note: add parentheses around left hand side expression to silence this warning
            if (!strncmp(decoded_raw_data.c_str(), KEY_IMAGE_EXPORT_FILE_MAGIC, magiclen) == 0)
                ^
                (                                                                        )
~/onion-monero-blockchain-explorer/src/page.h:3277:17: warning: logical not is only applied to the left hand side of this comparison
      [-Wlogical-not-parentheses]
            if (!strncmp(decoded_raw_data.c_str(), OUTPUT_EXPORT_FILE_MAGIC, magiclen) == 0)
                ^                                                                      ~~
~/onion-monero-blockchain-explorer/src/page.h:3277:17: note: add parentheses after the '!' to evaluate the comparison first
            if (!strncmp(decoded_raw_data.c_str(), OUTPUT_EXPORT_FILE_MAGIC, magiclen) == 0)
                ^
                 (                                                                         )
~/onion-monero-blockchain-explorer/src/page.h:3277:17: note: add parentheses around left hand side expression to silence this warning
            if (!strncmp(decoded_raw_data.c_str(), OUTPUT_EXPORT_FILE_MAGIC, magiclen) == 0)
                ^
                (                                                                     )
~/onion-monero-blockchain-explorer/main.cpp:396:9: warning: control may reach end of non-void lambda [-Wreturn-type]
        });
        ^
```
