### PR TITLE
build: readline is optional and shouldn't be relevant for the explorer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,9 +116,7 @@ set(LIBRARIES
         easylogging
         checkpoints
         version
-        epee_readline
         epee
-        readline
         ${Boost_LIBRARIES}
         pthread
         unbound
@@ -127,7 +125,7 @@ set(LIBRARIES
         ssl)
 
 if(APPLE)
-    set(LIBRARIES ${LIBRARIES} "-framework IOKit")
+    set(LIBRARIES ${LIBRARIES} "-framework IOKit -framework PCSC")
 else()
     set(LIBRARIES ${LIBRARIES} atomic)
 endif()

--- a/cmake/FindMonero.cmake
+++ b/cmake/FindMonero.cmake
@@ -28,7 +28,7 @@
 # (c) 2014-2016 cpp-ethereum contributors.
 #------------------------------------------------------------------------------
 
-set(LIBS common;blocks;cryptonote_basic;cryptonote_core;epee_readline;
+set(LIBS common;blocks;cryptonote_basic;cryptonote_core;
 		cryptonote_protocol;daemonizer;mnemonics;epee;lmdb;device;
 		blockchain_db;ringct;wallet;cncrypto;easylogging;version;checkpoints)
 


### PR DESCRIPTION
mac build: link against framework PCSC

I *believe* readline should be unnecessary.