### PR TITLE
Support newbp

### DIFF
--- a/src/MempoolStatus.cpp
+++ b/src/MempoolStatus.cpp
@@ -168,7 +168,7 @@ MempoolStatus::read_mempool()
         last_tx.mixin_no          = sum_data[2];
         last_tx.num_nonrct_inputs = sum_data[3];
 
-        last_tx.fee_str          = xmreg::xmr_amount_to_str(_tx_info.fee, "{:0.3f}", false);
+        last_tx.fee_str          = xmreg::xmr_amount_to_str(_tx_info.fee, "{:0.4f}", false);
         last_tx.payed_for_kB_str = fmt::format("{:0.4f}", payed_for_kB);
         last_tx.xmr_inputs_str   = xmreg::xmr_amount_to_str(last_tx.sum_inputs , "{:0.3f}");
         last_tx.xmr_outputs_str  = xmreg::xmr_amount_to_str(last_tx.sum_outputs, "{:0.3f}");

--- a/src/page.h
+++ b/src/page.h
@@ -2539,7 +2539,7 @@ show_my_outputs(string tx_hash_str,
 
     //cout << "\nmixins: " << mix << '\n';
 
-    context["no_all_possible_mixins"] = all_possible_mixins.size();
+    context["no_all_possible_mixins"] = static_cast<uint64_t>(all_possible_mixins.size());
     context["all_possible_mixins_amount"] = all_possible_mixins_amount1;
 
 

--- a/src/page.h
+++ b/src/page.h
@@ -256,8 +256,8 @@ struct tx_details
 
             mixin_str        = std::to_string(mixin_no);
             fee_str          = fmt::format("{:0.6f}", xmr_amount);
-            fee_short_str    = fmt::format("{:0.3f}", xmr_amount);
-            payed_for_kB_str = fmt::format("{:0.3f}", payed_for_kB);
+            fee_short_str    = fmt::format("{:0.4f}", xmr_amount);
+            payed_for_kB_str = fmt::format("{:0.4f}", payed_for_kB);
         }
 
 
@@ -5542,7 +5542,7 @@ json_emission()
 
         string emission_blk_no   = std::to_string(current_values.blk_no - 1);
         string emission_coinbase = xmr_amount_to_str(current_values.coinbase, "{:0.3f}");
-        string emission_fee      = xmr_amount_to_str(current_values.fee, "{:0.3f}", false);
+        string emission_fee      = xmr_amount_to_str(current_values.fee, "{:0.4f}", false);
 
         j_data = json {
                 {"blk_no"  , current_values.blk_no - 1},

--- a/src/page.h
+++ b/src/page.h
@@ -653,7 +653,7 @@ index2(uint64_t page_no = 0, bool refresh_page = false)
         crypto::hash blk_hash = core_storage->get_block_id_by_height(i);
 
         // get block size in kB
-        double blk_size = static_cast<double>(core_storage->get_db().get_block_size(i))/1024.0;
+        double blk_size = static_cast<double>(core_storage->get_db().get_block_weight(i))/1024.0;
 
         string blk_size_str = fmt::format("{:0.2f}", blk_size);
 
@@ -1225,7 +1225,7 @@ show_block(uint64_t _blk_height)
     }
 
     // get block size in bytes
-    uint64_t blk_size = core_storage->get_db().get_block_size(_blk_height);
+    uint64_t blk_size = core_storage->get_db().get_block_weight(_blk_height);
 
     // miner reward tx
     transaction coinbase_tx = blk.miner_tx;
@@ -4610,7 +4610,7 @@ json_block(string block_no_or_hash)
 
 
     // get block size in bytes
-    uint64_t blk_size = core_storage->get_db().get_block_size(block_height);
+    uint64_t blk_size = core_storage->get_db().get_block_weight(block_height);
 
     // miner reward tx
     transaction coinbase_tx = blk.miner_tx;
@@ -4839,7 +4839,7 @@ json_transactions(string _page, string _limit)
         }
 
         // get block size in bytes
-        double blk_size = core_storage->get_db().get_block_size(i);
+        double blk_size = core_storage->get_db().get_block_weight(i);
 
         crypto::hash blk_hash = core_storage->get_block_id_by_height(i);
 

--- a/src/rpccalls.cpp
+++ b/src/rpccalls.cpp
@@ -275,9 +275,9 @@ rpccalls::get_dynamic_per_kb_fee_estimate(
         uint64_t& fee,
         string& error_msg)
 {
-    epee::json_rpc::request<COMMAND_RPC_GET_PER_KB_FEE_ESTIMATE::request>
+    epee::json_rpc::request<COMMAND_RPC_GET_BASE_FEE_ESTIMATE::request>
             req_t = AUTO_VAL_INIT(req_t);
-    epee::json_rpc::response<COMMAND_RPC_GET_PER_KB_FEE_ESTIMATE::response, std::string>
+    epee::json_rpc::response<COMMAND_RPC_GET_BASE_FEE_ESTIMATE::response, std::string>
             resp_t = AUTO_VAL_INIT(resp_t);
 
 

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -935,7 +935,7 @@ decode_ringct(rct::rctSig const& rv,
         switch (rv.type)
         {
             case rct::RCTTypeSimple:
-            case rct::RCTTypeSimpleBulletproof:
+            case rct::RCTTypeBulletproof:
                 amount = rct::decodeRctSimple(rv,
                                               rct::sk2rct(scalar1),
                                               i,
@@ -943,7 +943,6 @@ decode_ringct(rct::rctSig const& rv,
                                               hw::get_device("default"));
                 break;
             case rct::RCTTypeFull:
-            case rct::RCTTypeFullBulletproof:
                 amount = rct::decodeRct(rv,
                                         rct::sk2rct(scalar1),
                                         i,


### PR DESCRIPTION
Now that the new Bulletproofs PR https://github.com/monero-project/monero/pull/4219 got merged and the testnet has rolled back, this patch fixes some compilation issues as well as increases the floating point precision when printing tx fees (because it became considerably smaller, often resulting in 0.000 being printed).