### PR TITLE
Update Readme.md to show aeonblocks.com alternate

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Mainnet
 
 Alternative block explorers:
 
-- [https://chainradar.com/aeon/blocks](https://chainradar.com/aeon/blocks)
+- [https://aeonblocks.com](https://aeonblocks.com)
 
 
 ## Compilation on Ubuntu 16.04

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Mainnet
 
 Alternative block explorers:
 
-- [https://aeonblocks.com](https://aeonblocks.com)
+- [http://aeon.lol/](http://aeon.lol/)
 
 
 ## Compilation on Ubuntu 16.04


### PR DESCRIPTION
Remove chainradar link as it is not supporting Aeon block explorer anymore. Replace with https://aeonblocks.com as it does currently support Aeon as an alternative block explorer.