### PR TITLE
port back to C++11 from C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(PROJECT_NAME
 
 project(${PROJECT_NAME})
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 11)
 
 if (WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wa,-mbig-obj -O3")

--- a/src/MempoolStatus.cpp
+++ b/src/MempoolStatus.cpp
@@ -139,9 +139,12 @@ MempoolStatus::read_mempool()
 
         mempool_size_kB += _tx_info.blob_size;
 
-        local_copy_of_mempool_txs.push_back(mempool_tx {tx_hash, tx});
+        local_copy_of_mempool_txs.push_back(mempool_tx{});
 
         mempool_tx& last_tx = local_copy_of_mempool_txs.back();
+
+        last_tx.tx_hash = tx_hash;
+        last_tx.tx = tx;
 
         // key images of inputs
         vector<txin_to_key> input_key_imgs;

--- a/src/page.h
+++ b/src/page.h
@@ -119,13 +119,14 @@ namespace std
  * visitor to produce json representations of
  * values stored in mstch::node
  */
-class mstch_node_to_json: public boost::static_visitor<nlohmann::json> {
+class mstch_node_to_json: public boost::static_visitor<nlohmann::json>
+{
 public:
 
 
     // enabled for numeric types
     template<typename T>
-    std::enable_if_t<std::is_arithmetic<T>::value, nlohmann::json>
+    typename  std::enable_if<std::is_arithmetic<T>::value, nlohmann::json>::type
     operator()(T const& value) const {
         return nlohmann::json {value};
     }
@@ -157,7 +158,7 @@ public:
 
     // catch other types that are non-numeric and not listed above
     template<typename T>
-    std::enable_if_t<!std::is_arithmetic<T>::value, nlohmann::json>
+    typename std::enable_if<!std::is_arithmetic<T>::value, nlohmann::json>::type
     operator()(const T&) const {
         return nlohmann::json {};
     }


### PR DESCRIPTION
To correct the following compile issues http://paste.debian.net/1073040/

applying commit below to aeon branch. (THANKS CAM)

[commit 6a1a6c48f](https://github.com/moneroexamples/onion-monero-blockchain-explorer/commit/6a1a6c48f830d1b38baa16e462db1605916c5998)

