### PR TITLE
support 128 bit difficulty type

### DIFF
--- a/src/MempoolStatus.cpp
+++ b/src/MempoolStatus.cpp
@@ -254,8 +254,11 @@ MempoolStatus::read_network_info()
     local_copy.height                     = rpc_network_info.height;
     local_copy.target_height              = rpc_network_info.target_height;
     local_copy.difficulty                 = rpc_network_info.difficulty;
+    local_copy.difficulty_top64           = rpc_network_info.difficulty_top64;
     local_copy.target                     = rpc_network_info.target;
-    local_copy.hash_rate                  = (rpc_network_info.difficulty/rpc_network_info.target);
+    cryptonote::difficulty_type hash_rate = cryptonote::difficulty_type(rpc_network_info.wide_difficulty) / rpc_network_info.target;
+    local_copy.hash_rate                  = (hash_rate & 0xFFFFFFFFFFFFFFFF).convert_to<uint64_t>();
+    local_copy.hash_rate_top64            = ((hash_rate >> 64) & 0xFFFFFFFFFFFFFFFF).convert_to<uint64_t>();
     local_copy.tx_count                   = rpc_network_info.tx_count;
     local_copy.tx_pool_size               = rpc_network_info.tx_pool_size;
     local_copy.alt_blocks_count           = rpc_network_info.alt_blocks_count;
@@ -265,6 +268,7 @@ MempoolStatus::read_network_info()
     local_copy.nettype                    = rpc_network_info.testnet ? cryptonote::network_type::TESTNET : 
                                             rpc_network_info.stagenet ? cryptonote::network_type::STAGENET : cryptonote::network_type::MAINNET;
     local_copy.cumulative_difficulty      = rpc_network_info.cumulative_difficulty;
+    local_copy.cumulative_difficulty_top64 = rpc_network_info.cumulative_difficulty_top64;
     local_copy.block_size_limit           = rpc_network_info.block_size_limit;
     local_copy.block_size_median          = rpc_network_info.block_size_median;
     local_copy.start_time                 = rpc_network_info.start_time;

--- a/src/MempoolStatus.h
+++ b/src/MempoolStatus.h
@@ -59,6 +59,7 @@ struct MempoolStatus
         uint64_t height  {0};
         uint64_t target_height  {0};
         uint64_t difficulty  {0};
+        uint64_t difficulty_top64  {0};
         uint64_t target  {0};
         uint64_t tx_count  {0};
         uint64_t tx_pool_size  {0};
@@ -70,6 +71,7 @@ struct MempoolStatus
         cryptonote::network_type nettype {cryptonote::network_type::MAINNET};
         crypto::hash top_block_hash;
         uint64_t cumulative_difficulty  {0};
+        uint64_t cumulative_difficulty_top64  {0};
         uint64_t block_size_limit  {0};
         uint64_t block_size_median  {0};
         char block_size_limit_str[10];   // needs to be trivially copyable
@@ -78,6 +80,7 @@ struct MempoolStatus
         uint64_t current_hf_version {0};
 
         uint64_t hash_rate  {0};
+        uint64_t hash_rate_top64  {0};
         uint64_t fee_per_kb  {0};
         uint64_t info_timestamp  {0};
 

--- a/src/page.h
+++ b/src/page.h
@@ -884,13 +884,15 @@ index2(uint64_t page_no = 0, bool refresh_page = false)
 
     // perapre network info mstch::map for the front page
     string hash_rate;
+    double hr_d;
+    char metric_prefix;
+    cryptonote::difficulty_type hr = make_difficulty(current_network_info.hash_rate, current_network_info.hash_rate_top64);
+    get_metric_prefix(hr, hr_d, metric_prefix);
 
-    if (current_network_info.hash_rate > 1e6)
-        hash_rate = fmt::format("{:0.3f} MH/s", current_network_info.hash_rate/1.0e6);
-    else if (current_network_info.hash_rate > 1e3)
-        hash_rate = fmt::format("{:0.3f} kH/s", current_network_info.hash_rate/1.0e3);
+    if (metric_prefix != 0)
+        hash_rate = fmt::format("{:0.3f} {:c}H/s", hr_d, metric_prefix);
     else
-        hash_rate = fmt::format("{:d} H/s", current_network_info.hash_rate);
+        hash_rate = fmt::format("{:s} H/s", hr.str());
 
     pair<string, string> network_info_age = get_age(local_copy_server_timestamp,
                                                     current_network_info.info_timestamp);
@@ -903,7 +905,7 @@ index2(uint64_t page_no = 0, bool refresh_page = false)
     }
 
     context["network_info"] = mstch::map {
-            {"difficulty"        , current_network_info.difficulty},
+            {"difficulty"        , make_difficulty(current_network_info.difficulty, current_network_info.difficulty_top64).str()},
             {"hash_rate"         , hash_rate},
             {"fee_per_kb"        , print_money(current_network_info.fee_per_kb)},
             {"alt_blocks_no"     , current_network_info.alt_blocks_count},
@@ -1246,7 +1248,7 @@ show_block(uint64_t _blk_height)
     // initalise page tempate map with basic info about blockchain
 
     string blk_pow_hash_str = pod_to_hex(get_block_longhash(blk, _blk_height));
-    uint64_t blk_difficulty = core_storage->get_db().get_block_difficulty(_blk_height);
+    cryptonote::difficulty_type blk_difficulty = core_storage->get_db().get_block_difficulty(_blk_height);
 
     mstch::map context {
             {"testnet"              , testnet},
@@ -1267,7 +1269,7 @@ show_block(uint64_t _blk_height)
             {"delta_time"           , delta_time},
             {"blk_nonce"            , blk.nonce},
             {"blk_pow_hash"         , blk_pow_hash_str},
-            {"blk_difficulty"       , blk_difficulty},
+            {"blk_difficulty"       , blk_difficulty.str()},
             {"age_format"           , age.second},
             {"major_ver"            , std::to_string(blk.major_version)},
             {"minor_ver"            , std::to_string(blk.minor_version)},
@@ -6581,7 +6583,7 @@ get_monero_network_info(json& j_info)
        {"current"                   , local_copy_network_info.current},
        {"height"                    , local_copy_network_info.height},
        {"target_height"             , local_copy_network_info.target_height},
-       {"difficulty"                , local_copy_network_info.difficulty},
+       {"difficulty"                , make_difficulty(local_copy_network_info.difficulty, local_copy_network_info.difficulty_top64).str()},
        {"target"                    , local_copy_network_info.target},
        {"hash_rate"                 , local_copy_network_info.hash_rate},
        {"tx_count"                  , local_copy_network_info.tx_count},
@@ -6594,7 +6596,7 @@ get_monero_network_info(json& j_info)
        {"testnet"                   , local_copy_network_info.nettype == cryptonote::network_type::TESTNET},
        {"stagenet"                  , local_copy_network_info.nettype == cryptonote::network_type::STAGENET},
        {"top_block_hash"            , pod_to_hex(local_copy_network_info.top_block_hash)},
-       {"cumulative_difficulty"     , local_copy_network_info.cumulative_difficulty},
+       {"cumulative_difficulty"     , make_difficulty(local_copy_network_info.cumulative_difficulty, local_copy_network_info.cumulative_difficulty_top64).str()},
        {"block_size_limit"          , local_copy_network_info.block_size_limit},
        {"block_size_median"         , local_copy_network_info.block_size_median},
        {"start_time"                , local_copy_network_info.start_time},

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -1272,4 +1272,31 @@ tx_to_hex(transaction const& tx)
     return epee::string_tools::buff_to_hex_nodelimer(t_serializable_object_to_blob(tx));
 }
 
+void get_metric_prefix(cryptonote::difficulty_type hr, double& hr_d, char& prefix)
+{
+  if (hr < 1000)
+  {
+    prefix = 0;
+    return;
+  }
+  static const char metric_prefixes[4] = { 'k', 'M', 'G', 'T' };
+  for (size_t i = 0; i < sizeof(metric_prefixes); ++i)
+  {
+    if (hr < 1000000)
+    {
+      hr_d = hr.convert_to<double>() / 1000;
+      prefix = metric_prefixes[i];
+      return;
+    }
+    hr /= 1000;
+  }
+  prefix = 0;
+}
+
+cryptonote::difficulty_type
+make_difficulty(uint64_t low, uint64_t high)
+{
+    return (cryptonote::difficulty_type(high) << 64) + low;
+}
+
 }

--- a/src/tools.h
+++ b/src/tools.h
@@ -373,6 +373,12 @@ pause_execution(uint64_t no_seconds, const string& text = "now");
 string
 tx_to_hex(transaction const& tx);
 
+void
+get_metric_prefix(cryptonote::difficulty_type hr, double& hr_d, char& prefix);
+
+cryptonote::difficulty_type
+make_difficulty(uint64_t low, uint64_t high);
+
 }
 
 #endif //XMREG01_TOOLS_H


### PR DESCRIPTION
Aeon is going to switch to KangarooTwelve proof of work (https://github.com/aeonix/aeon/pull/108) which necessitates an increased bit length for the difficulty value (which is done by cherry-picking https://github.com/monero-project/monero/pull/5239).

Please merge this PR when the above Aeon PR gets merged (I'll ping you).
