### PR TITLE
turn off SSL when connecting to the daemon

### DIFF
--- a/src/rpccalls.cpp
+++ b/src/rpccalls.cpp
@@ -21,7 +21,7 @@ rpccalls::rpccalls(string _deamon_url,
 
     m_http_client.set_server(
             deamon_url,
-            boost::optional<epee::net_utils::http::login>{});
+            boost::optional<epee::net_utils::http::login>{}, epee::net_utils::ssl_support_t::e_ssl_support_disabled);
 }
 
 bool


### PR DESCRIPTION
Otherwise it repeats displaying
```
2019-04-05 06:10:29.521	  0x7000053a5000	INFO	global	contrib/epee/src/net_ssl.cpp:75	Generating SSL certificate
mempool status txs: 0
```
while taking an unreasonable amount of CPU load.