### PR TITLE
Add autorefresh on /tx page.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -326,6 +326,16 @@ main(int ac, const char* av[])
         return myxmr::htmlresponse(
                 xmrblocks.show_tx(remove_bad_chars(tx_hash)));
     });
+    if (enable_autorefresh_option)
+    {
+        CROW_ROUTE(app, "/tx/<string>/autorefresh")
+        ([&](string tx_hash) {
+            bool refresh_page {true};
+            uint16_t with_ring_signatures {0};
+            return myxmr::htmlresponse(
+                xmrblocks.show_tx(remove_bad_chars(tx_hash), with_ring_signatures, refresh_page));
+        });
+    }
 
     if (enable_as_hex)
     {
@@ -375,6 +385,15 @@ main(int ac, const char* av[])
                 xmrblocks.show_tx(remove_bad_chars(tx_hash), 
                     with_ring_signatures));
     });
+    if (enable_autorefresh_option)
+    {
+        CROW_ROUTE(app, "/tx/<string>/<uint>/autorefresh")
+        ([&](string tx_hash, uint16_t with_ring_signature) {
+            bool refresh_page {true};
+            return myxmr::htmlresponse(
+                xmrblocks.show_tx(remove_bad_chars(tx_hash), with_ring_signature, refresh_page));
+        });
+    }
 
     CROW_ROUTE(app, "/myoutputs").methods("POST"_method)
     ([&](const crow::request& req) -> myxmr::htmlresponse

--- a/src/page.h
+++ b/src/page.h
@@ -1414,7 +1414,7 @@ show_block(string _blk_hash)
 }
 
 string
-show_tx(string tx_hash_str, uint16_t with_ring_signatures = 0)
+show_tx(string tx_hash_str, uint16_t with_ring_signatures = 0, bool refresh_page = false)
 {
 
     // parse tx hash string to hash object
@@ -1629,7 +1629,9 @@ show_tx(string tx_hash_str, uint16_t with_ring_signatures = 0)
             {"testnet"          , this->testnet},
             {"stagenet"         , this->stagenet},
             {"show_cache_times" , show_cache_times},
-            {"txs"              , mstch::array{}}
+            {"txs"              , mstch::array{}},
+            {"refresh"          , refresh_page},
+            {"tx_hash"          , tx_hash_str}
     };
 
     boost::get<mstch::array>(context["txs"]).push_back(tx_context);

--- a/src/templates/tx.html
+++ b/src/templates/tx.html
@@ -1,4 +1,15 @@
 
+<div class="center">
+     <h3 style="font-size: 12px; margin-top: 20px">
+     {{#refresh}}
+         <a href="/tx/{{tx_hash}}">Autorefresh is ON (10 s)</a>
+     {{/refresh}}
+     {{^refresh}}
+        <a href="/tx/{{tx_hash}}/autorefresh">Autorefresh is OFF</a>
+     {{/refresh}}
+     </h3>
+</div>
+
 <div>
 
     {{#has_error}}


### PR DESCRIPTION
I always liked the idea of having the autorefresh option on the `/txt/<tx_hash>` page as well.

I sometimes go there and wait for the confirmations to come in. Autorefreshing the page makes it more of an experience :)

It uses the exact same mechanism and flag (`--enable-autorefresh-option`) already provided by the index page.

