### PR TITLE
Add autorefresh Content-Type.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -808,7 +808,7 @@ main(int ac, const char* av[])
         ([&]() {
             uint64_t page_no {0};
             bool refresh_page {true};
-            return xmrblocks.index2(page_no, refresh_page);
+            return myxmr::htmlresponse(xmrblocks.index2(page_no, refresh_page));
         });
     }
 


### PR DESCRIPTION
Google Chrome only showed the source code when clicking **Autorefresh** on the main page.

This PR now returns the proper Content-Type.

By the way, firefox never complained and always rendered the **Autorefresh** correctly.