### PR TITLE
Add tx_confirmations to resultset in api/outputs

### DIFF
--- a/src/page.h
+++ b/src/page.h
@@ -5413,6 +5413,7 @@ json_outputs(string tx_hash_str,
     j_data["address"]  = pod_to_hex(address_info.address);
     j_data["viewkey"]  = pod_to_hex(prv_view_key);
     j_data["tx_prove"] = tx_prove;
+    j_data["tx_confirmations"] = txd.no_confirmations;
 
     j_response["status"] = "success";
 


### PR DESCRIPTION
Adding the count of confirmations (tx_confirmations) enables this API to prove that a transaction has been both sent and confirmed in the blockchain.

Ref: https://github.com/bisq-network/bisq/pull/4378#issuecomment-669629274