### PR TITLE
Fix typos

### DIFF
--- a/src/templates/randomx.html
+++ b/src/templates/randomx.html
@@ -2,8 +2,8 @@
 
     <H4>Block hash (height): {{blk_hash}} ({{blk_height}})</H4>
     <h4>
-        Eight RandomX and correspoding assembly x86 programs used
-        to calcualte the PoW hash of the block.<br/>
+        Eight RandomX and corresponding assembly x86 programs used
+        to calculate the PoW hash of the block.<br/>
 	    The RandomX programs are executed on RandomX virtual machine. 
     </h4>
     <h5>


### PR DESCRIPTION
Fix a couple of typos in `randomx.html` 