### PR TITLE
iPhone Mobile view fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ special importance to privacy-oriented users:
 
  - they use JavaScript,
  - have images which might be used for [cookieless tracking](http://lucb1e.com/rp/cookielesscookies/),
- - track users activates through google analytics,
+ - track users activities through google analytics,
  - are closed sourced,
  - are not available as hidden services,
  - do not support Monero testnet nor stagenet networks,
@@ -46,7 +46,7 @@ i2p users (main Monero network):
 
 Alternative block explorers:
 
-- [http://moneroblocks.info](http://moneroblocks.info/)
+- [https://localmonero.co/blocks](https://localmonero.co/blocks)
 - [https://monerovision.com](https://monerovision.com)
 
 
@@ -63,7 +63,7 @@ The key features of the Onion Monero Blockchain Explorer are:
  - showing public components of Monero addresses,
  - decoding which outputs and mixins belong to the given Monero address and viewkey,
  - can prove that you send Monero to someone,
- - detailed information about ring members, such as, their age, timescale and their ring sizes,
+ - detailed information about ring members, such as their age, timescale, and ring sizes,
  - showing number of amount output indices,
  - support Monero testnet and stagnet networks,
  - tx checker and pusher for online pushing of transactions,
@@ -231,7 +231,7 @@ Every 10000 blocks, the thread will save current emission in a file, by default,
  is present, read its values, and continue from there if possible. Subsequently, only the initial
  use of the tread is time consuming. Once the thread scans the entire blockchain, it updates
  the emission amount using new blocks as they come. Since the explorer writes this file, there can
- be only one instance of it running for mainnet, testnet and stagenet. Thus, for example, you cant have
+ be only one instance of it running for mainnet, testnet and stagenet. Thus, for example, you can't have
  two explorers for mainnet
  running at the same time, as they will be trying to write and read the same file at the same time,
  leading to unexpected results. Off course having one instance for mainnet and one instance for testnet
@@ -269,7 +269,7 @@ Having the `crt` and `key` files, run `xmrblocks` in the following way:
 ```
 
 Note: Because we generated our own certificate, modern browsers will complain
-about it as they cant verify the signatures against any third party. So probably
+about it as they can't verify the signatures against any third party. So probably
 for any practical use need to have properly issued ssl certificates.
 
 ## JSON API

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Every 10000 blocks, the thread will save current emission in a file, by default,
  need to rescan entire blockchain whenever the explorer is restarted. When the
  explorer restarts, the thread will first check if `~/.bitmonero/lmdb/emission_amount.txt`
  is present, read its values, and continue from there if possible. Subsequently, only the initial
- use of the tread is time consuming. Once the thread scans the entire blockchain, it updates
+ use of the thread is time consuming. Once the thread scans the entire blockchain, it updates
  the emission amount using new blocks as they come. Since the explorer writes this file, there can
  be only one instance of it running for mainnet, testnet and stagenet. Thus, for example, you can't have
  two explorers for mainnet

--- a/src/templates/css/style.css
+++ b/src/templates/css/style.css
@@ -101,6 +101,7 @@ form {
     bottom: 0;
     padding: 20px;
     border: 1px solid #ccc;
+    display: none;
 }
 
 [type=radio]:checked ~ label {
@@ -111,6 +112,11 @@ form {
 
 [type=radio]:checked ~ label ~ .content {
     z-index: 1;
+}
+
+#tab-1:checked ~ .content.tab-1,
+#tab-2:checked ~ .content.tab-2 {
+    display: block;
 }
 
 input#toggle-1[type=checkbox] {

--- a/src/templates/partials/tx_details.html
+++ b/src/templates/partials/tx_details.html
@@ -80,7 +80,7 @@
             <div class="tab">
                 <input type="radio" id="tab-1" name="tab-group-1" checked>
                 <label for="tab-1">Decode outputs</label>
-                <div class="content">
+                <div class="content tab-1">
                     <h4 style="margin: 0px">Check which outputs belong to given Monero address/subaddress and viewkey</h4>
                     <h5 style="margin: 0px">
                         For RingCT transactions, outputs' amounts are also decoded
@@ -102,7 +102,7 @@
                 <input type="radio" id="tab-2" name="tab-group-1">
                 <label for="tab-2">Prove sending</label>
 
-                <div class="content">
+                <div class="content tab-2">
                     <h4 style="margin: 0px">Prove to someone that you have sent them Monero in this transaction</h4>
                     <h5 style="margin: 0px">
                         Tx private key can be obtained using <i>get_tx_key</i>


### PR DESCRIPTION
fixed safari iPhone issue where Prove Sending fields appear when user is in Decode outputs tab
Closes #237 

To reproduce issue:
1. go to xmrchain.net on safari using iPhone
2. select any transaction
3. Go to Decout Outputs tab
4. see the Prove Sending inputs appearing when user is on the Decode outputs tab