### PR TITLE
Correct misspelling of "daemon" for "daemon-url"

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ xmrblocks, Onion Monero Blockchain Explorer:
                                         functionality
   --ssl-key-file arg                    path to key file for ssl (https)
                                         functionality
-  -d [ --deamon-url ] arg (=http:://127.0.0.1:18081)
+  -d [ --daemon-url ] arg (=http:://127.0.0.1:18081)
                                         Monero daemon url
   --daemon-login arg                    Specify username[:password] for daemon 
                                         RPC client

--- a/main.cpp
+++ b/main.cpp
@@ -56,7 +56,7 @@ main(int ac, const char* av[])
     auto port_opt                      = opts.get_option<string>("port");
     auto bindaddr_opt                  = opts.get_option<string>("bindaddr");
     auto bc_path_opt                   = opts.get_option<string>("bc-path");
-    auto deamon_url_opt                = opts.get_option<string>("deamon-url");
+    auto daemon_url_opt                = opts.get_option<string>("daemon-url");
     auto ssl_crt_file_opt              = opts.get_option<string>("ssl-crt-file");
     auto ssl_key_file_opt              = opts.get_option<string>("ssl-key-file");
     auto no_blocks_on_index_opt        = opts.get_option<string>("no-blocks-on-index");
@@ -205,12 +205,12 @@ main(int ac, const char* av[])
         return EXIT_FAILURE;
     }
 
-    string deamon_url {*deamon_url_opt};
+    string daemon_url {*daemon_url_opt};
 
-    if (testnet && deamon_url == "http:://127.0.0.1:18081")
-        deamon_url = "http:://127.0.0.1:28081";
-    if (stagenet && deamon_url == "http:://127.0.0.1:18081")
-        deamon_url = "http:://127.0.0.1:38081";
+    if (testnet && daemon_url == "http:://127.0.0.1:18081")
+        daemon_url = "http:://127.0.0.1:28081";
+    if (stagenet && daemon_url == "http:://127.0.0.1:18081")
+        daemon_url = "http:://127.0.0.1:38081";
 
     uint64_t mempool_info_timeout {5000};
 
@@ -247,8 +247,8 @@ main(int ac, const char* av[])
                 = blockchain_path;
         xmreg::CurrentBlockchainStatus::nettype
                 = nettype;
-        xmreg::CurrentBlockchainStatus::deamon_url
-                = deamon_url;
+        xmreg::CurrentBlockchainStatus::daemon_url
+                = daemon_url;
         xmreg::CurrentBlockchainStatus::set_blockchain_variables(
                 &mcore, core_storage);
 
@@ -264,8 +264,8 @@ main(int ac, const char* av[])
             = blockchain_path;
     xmreg::MempoolStatus::nettype
             = nettype;
-    xmreg::MempoolStatus::deamon_url
-            = deamon_url;
+    xmreg::MempoolStatus::daemon_url
+            = daemon_url;
     xmreg::MempoolStatus::login
             = daemon_rpc_login;
     xmreg::MempoolStatus::set_blockchain_variables(
@@ -299,7 +299,7 @@ main(int ac, const char* av[])
     // contains logic for the website
     xmreg::page xmrblocks(&mcore,
                           core_storage,
-                          deamon_url,
+                          daemon_url,
                           nettype,
                           enable_pusher,
                           enable_randomx,

--- a/src/CmdLineOptions.cpp
+++ b/src/CmdLineOptions.cpp
@@ -71,7 +71,7 @@ namespace xmreg
                  "path to key file for ssl (https) functionality")
                 ("daemon-login", value<string>(),
                  "Specify username[:password] for daemon RPC client")
-                ("deamon-url,d", value<string>()->default_value("http:://127.0.0.1:18081"),
+                ("daemon-url,d", value<string>()->default_value("http:://127.0.0.1:18081"),
                  "Monero daemon url");
 
 

--- a/src/CurrentBlockchainStatus.cpp
+++ b/src/CurrentBlockchainStatus.cpp
@@ -303,7 +303,7 @@ cryptonote::network_type CurrentBlockchainStatus::nettype {cryptonote::network_t
 
 string CurrentBlockchainStatus::output_file {"emission_amount.txt"};
 
-string CurrentBlockchainStatus::deamon_url {"http:://127.0.0.1:18081"};
+string CurrentBlockchainStatus::daemon_url {"http:://127.0.0.1:18081"};
 
 uint64_t  CurrentBlockchainStatus::blockchain_chunk_size {10000};
 

--- a/src/CurrentBlockchainStatus.h
+++ b/src/CurrentBlockchainStatus.h
@@ -51,7 +51,7 @@ struct CurrentBlockchainStatus
 
     static string output_file;
 
-    static string deamon_url;
+    static string daemon_url;
 
     // how many blocks to read before thread goes to sleep
     static uint64_t blockchain_chunk_size;

--- a/src/MempoolStatus.cpp
+++ b/src/MempoolStatus.cpp
@@ -96,7 +96,7 @@ MempoolStatus::start_mempool_status_thread()
 bool
 MempoolStatus::read_mempool()
 {
-    rpccalls rpc {deamon_url, login};
+    rpccalls rpc {daemon_url, login};
 
     string error_msg;
 
@@ -222,7 +222,7 @@ MempoolStatus::read_mempool()
 bool
 MempoolStatus::read_network_info()
 {
-    rpccalls rpc {deamon_url, login};
+    rpccalls rpc {daemon_url, login};
 
     COMMAND_RPC_GET_INFO::response rpc_network_info;
 
@@ -326,7 +326,7 @@ MempoolStatus::is_thread_running()
 }
 
 bf::path MempoolStatus::blockchain_path {"/home/mwo/.bitmonero/lmdb"};
-string MempoolStatus::deamon_url {"http:://127.0.0.1:18081"};
+string MempoolStatus::daemon_url {"http:://127.0.0.1:18081"};
 cryptonote::network_type MempoolStatus::nettype {cryptonote::network_type::MAINNET};
 atomic<bool>       MempoolStatus::is_running {false};
 boost::thread      MempoolStatus::m_thread;

--- a/src/MempoolStatus.h
+++ b/src/MempoolStatus.h
@@ -125,7 +125,7 @@ struct MempoolStatus
     static atomic<uint64_t> mempool_size; // size in bytes.
 
     static bf::path blockchain_path;
-    static string deamon_url;
+    static string daemon_url;
     static cryptonote::network_type nettype;
 
     static rpccalls::login_opt login;

--- a/src/page.h
+++ b/src/page.h
@@ -498,7 +498,7 @@ public:
 
 page(MicroCore* _mcore,
      Blockchain* _core_storage,
-     string _deamon_url,
+     string _daemon_url,
      cryptonote::network_type _nettype,
      bool _enable_pusher,
      bool _enable_randomx,
@@ -515,7 +515,7 @@ page(MicroCore* _mcore,
      rpccalls::login_opt _daemon_rpc_login)
         : mcore {_mcore},
           core_storage {_core_storage},
-          rpc {_deamon_url, _daemon_rpc_login},
+          rpc {_daemon_url, _daemon_rpc_login},
           server_timestamp {std::time(nullptr)},
           nettype {_nettype},
           enable_pusher {_enable_pusher},
@@ -577,9 +577,9 @@ index2(uint64_t page_no = 0, bool refresh_page = false)
 {
 
     // we get network info, such as current hash rate
-    // but since this makes a rpc call to deamon, we make it as an async
+    // but since this makes a rpc call to daemon, we make it as an async
     // call. this way we dont have to wait with execution of the rest of the
-    // index2 method, until deamon gives as the required result.
+    // index2 method, until daemon gives as the required result.
     std::future<json> network_info_ftr = std::async(std::launch::async, [&]
     {
         json j_info;

--- a/src/rpccalls.cpp
+++ b/src/rpccalls.cpp
@@ -9,26 +9,26 @@ namespace xmreg
 
 
 rpccalls::rpccalls(
-         string _deamon_url,
+         string _daemon_url,
          login_opt login,
          uint64_t _timeout)
-        : deamon_url {_deamon_url},
+        : daemon_url {_daemon_url},
           timeout_time {_timeout}
 {
-    epee::net_utils::parse_url(deamon_url, url);
+    epee::net_utils::parse_url(daemon_url, url);
 
     port = std::to_string(url.port);
 
     timeout_time_ms = std::chrono::milliseconds {timeout_time};    
 
      m_http_client.set_server(
-             deamon_url,
+             daemon_url,
              login,
              epee::net_utils::ssl_support_t::e_ssl_support_disabled);
 }
 
 bool
-rpccalls::connect_to_monero_deamon()
+rpccalls::connect_to_monero_daemon()
 {
     //std::lock_guard<std::mutex> guard(m_daemon_rpc_mutex);
 
@@ -48,9 +48,9 @@ rpccalls::get_current_height()
 
     std::lock_guard<std::mutex> guard(m_daemon_rpc_mutex);
 
-    if (!connect_to_monero_deamon())
+    if (!connect_to_monero_daemon())
     {
-        cerr << "get_current_height: not connected to deamon" << endl;
+        cerr << "get_current_height: not connected to daemon" << endl;
         return false;
     }
 
@@ -60,8 +60,8 @@ rpccalls::get_current_height()
 
     if (!r)
     {
-        cerr << "Error connecting to Monero deamon at "
-             << deamon_url << endl;
+        cerr << "Error connecting to Monero daemon at "
+             << daemon_url << endl;
         return 0;
     }
 
@@ -80,9 +80,9 @@ rpccalls::get_mempool(vector<tx_info>& mempool_txs)
     {
         std::lock_guard<std::mutex> guard(m_daemon_rpc_mutex);
 
-        if (!connect_to_monero_deamon())
+        if (!connect_to_monero_daemon())
         {
-            cerr << "get_mempool: not connected to deamon" << endl;
+            cerr << "get_mempool: not connected to daemon" << endl;
             return false;
         }
 
@@ -93,8 +93,8 @@ rpccalls::get_mempool(vector<tx_info>& mempool_txs)
 
     if (!r || res.status != CORE_RPC_STATUS_OK)
     {
-        cerr << "Error connecting to Monero deamon at "
-             << deamon_url << endl;
+        cerr << "Error connecting to Monero daemon at "
+             << daemon_url << endl;
         return false;
     }
 
@@ -127,9 +127,9 @@ rpccalls::commit_tx(tools::wallet2::pending_tx& ptx, string& error_msg)
 
     std::lock_guard<std::mutex> guard(m_daemon_rpc_mutex);
 
-    if (!connect_to_monero_deamon())
+    if (!connect_to_monero_daemon())
     {
-        cerr << "commit_tx: not connected to deamon" << endl;
+        cerr << "commit_tx: not connected to daemon" << endl;
         return false;
     }
 
@@ -166,9 +166,9 @@ rpccalls::get_network_info(COMMAND_RPC_GET_INFO::response& response)
     {
         std::lock_guard<std::mutex> guard(m_daemon_rpc_mutex);
 
-        if (!connect_to_monero_deamon())
+        if (!connect_to_monero_daemon())
         {
-            cerr << "get_network_info: not connected to deamon" << endl;
+            cerr << "get_network_info: not connected to daemon" << endl;
             return false;
         }
 
@@ -192,15 +192,15 @@ rpccalls::get_network_info(COMMAND_RPC_GET_INFO::response& response)
 
         if (!err.empty())
         {
-            cerr << "Error connecting to Monero deamon due to "
+            cerr << "Error connecting to Monero daemon due to "
                  << err << endl;
             return false;
         }
     }
     else
     {
-        cerr << "Error connecting to Monero deamon at "
-             << deamon_url << endl;
+        cerr << "Error connecting to Monero daemon at "
+             << daemon_url << endl;
         return false;
     }
 
@@ -226,9 +226,9 @@ rpccalls::get_hardfork_info(COMMAND_RPC_HARD_FORK_INFO::response& response)
     {
         std::lock_guard<std::mutex> guard(m_daemon_rpc_mutex);
 
-        if (!connect_to_monero_deamon())
+        if (!connect_to_monero_daemon())
         {
-            cerr << "get_hardfork_info: not connected to deamon" << endl;
+            cerr << "get_hardfork_info: not connected to daemon" << endl;
             return false;
         }
 
@@ -253,15 +253,15 @@ rpccalls::get_hardfork_info(COMMAND_RPC_HARD_FORK_INFO::response& response)
 
         if (!err.empty())
         {
-            cerr << "Error connecting to Monero deamon due to "
+            cerr << "Error connecting to Monero daemon due to "
                  << err << endl;
             return false;
         }
     }
     else
     {
-        cerr << "Error connecting to Monero deamon at "
-             << deamon_url << endl;
+        cerr << "Error connecting to Monero daemon at "
+             << daemon_url << endl;
         return false;
     }
 
@@ -294,9 +294,9 @@ rpccalls::get_dynamic_per_kb_fee_estimate(
     {
         std::lock_guard<std::mutex> guard(m_daemon_rpc_mutex);
 
-        if (!connect_to_monero_deamon())
+        if (!connect_to_monero_daemon())
         {
-            cerr << "get_dynamic_per_kb_fee_estimate: not connected to deamon" << endl;
+            cerr << "get_dynamic_per_kb_fee_estimate: not connected to daemon" << endl;
             return false;
         }
 
@@ -321,15 +321,15 @@ rpccalls::get_dynamic_per_kb_fee_estimate(
 
         if (!err.empty())
         {
-            cerr << "Error connecting to Monero deamon due to "
+            cerr << "Error connecting to Monero daemon due to "
                  << err << endl;
             return false;
         }
     }
     else
     {
-        cerr << "Error connecting to Monero deamon at "
-             << deamon_url << endl;
+        cerr << "Error connecting to Monero daemon at "
+             << daemon_url << endl;
         return false;
     }
 
@@ -357,9 +357,9 @@ rpccalls::get_block(string const& blk_hash, block& blk, string& error_msg)
     {
         std::lock_guard<std::mutex> guard(m_daemon_rpc_mutex);
 
-        if (!connect_to_monero_deamon())
+        if (!connect_to_monero_daemon())
         {
-            cerr << "get_block: not connected to deamon" << endl;
+            cerr << "get_block: not connected to daemon" << endl;
             return false;
         }
 
@@ -384,15 +384,15 @@ rpccalls::get_block(string const& blk_hash, block& blk, string& error_msg)
 
         if (!err.empty())
         {
-            cerr << "Error connecting to Monero deamon due to "
+            cerr << "Error connecting to Monero daemon due to "
                  << err << endl;
             return false;
         }
     }
     else
     {
-        cerr << "get_block: error connecting to Monero deamon at "
-             << deamon_url << endl;
+        cerr << "get_block: error connecting to Monero daemon at "
+             << daemon_url << endl;
         return false;
     }
 

--- a/src/rpccalls.h
+++ b/src/rpccalls.h
@@ -69,7 +69,7 @@ using namespace std;
 
 class rpccalls
 {
-    string deamon_url ;
+    string daemon_url ;
     uint64_t timeout_time;
 
     std::chrono::milliseconds timeout_time_ms;
@@ -85,12 +85,12 @@ public:
 
     using login_opt = boost::optional<epee::net_utils::http::login>;
 
-    rpccalls(string _deamon_url = "http:://127.0.0.1:18081",
+    rpccalls(string _daemon_url = "http:://127.0.0.1:18081",
              login_opt _login = login_opt {},
              uint64_t _timeout = 200000);
 
     bool
-    connect_to_monero_deamon();
+    connect_to_monero_daemon();
 
     uint64_t
     get_current_height();
@@ -135,9 +135,9 @@ public:
         {
             std::lock_guard<std::mutex> guard(m_daemon_rpc_mutex);
 
-            if (!connect_to_monero_deamon())
+            if (!connect_to_monero_daemon())
             {
-                cerr << "get_alt_blocks: not connected to deamon" << endl;
+                cerr << "get_alt_blocks: not connected to daemon" << endl;
                 return false;
             }
 
@@ -161,15 +161,15 @@ public:
 
             if (!err.empty())
             {
-                cerr << "Error connecting to Monero deamon due to "
+                cerr << "Error connecting to Monero daemon due to "
                      << err << endl;
                 return false;
             }
         }
         else
         {
-            cerr << "Error connecting to Monero deamon at "
-                 << deamon_url << endl;
+            cerr << "Error connecting to Monero daemon at "
+                 << daemon_url << endl;
             return false;
         }
 


### PR DESCRIPTION
Just a simple fix, as "daemon" was misspelled "deamon", even in the flag/arg.