### PR TITLE
Enable Github actions build of Docker image

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -1,0 +1,4 @@
+general:
+  vulnerabilities:
+    - CIS-DI-0005
+    - CIS-DI-0008

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -1,0 +1,37 @@
+name: Build and scan container for vulnerabilities with Trivy
+
+on:
+  push:
+    paths:
+    - 'Dockerfile'
+  pull_request:
+    paths:
+    - 'Dockerfile'
+  schedule:
+    - cron: '22 14 * * 0'
+
+jobs:
+  build:
+    name: Build
+    runs-on: "ubuntu-18.04"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build an image from Dockerfile
+        run: |
+          docker build -t docker.io/my-organization/my-app:${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/update-base-image.yml
+++ b/.github/workflows/update-base-image.yml
@@ -1,0 +1,56 @@
+name: "Update image and push to Github Packages and Docker Hub weekly"
+on:
+  schedule:
+    - cron: "0 12 * * 1" # Run every Monday at noon.
+  workflow_dispatch:
+jobs:
+  rebuild-container:
+    name: "Rebuild Container with the latest base image"
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.6.0
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1.10.0 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1.10.0 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: "Checkout repository"
+        uses: "actions/checkout@v2.3.4"
+      - 
+        name: "Get Monero Release Tag"
+        id: get_tag
+        run: echo "::set-output name=tag::$(awk -F "=" '/MONERO_BRANCH=/ {print $2}' Dockerfile)"
+      -
+        name: Build and push to Docker Hub and Github Packages Docker Registry
+        id: docker_build
+        uses: docker/build-push-action@v2.7.0
+        with:
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/xmrblocks:latest
+            ghcr.io/${{ github.repository_owner }}/xmrblocks:${{ steps.get_tag.outputs.tag }}
+            ${{ secrets.DOCKER_USERNAME }}/xmrblocks:latest
+            ${{ secrets.DOCKER_USERNAME }}/xmrblocks:${{ steps.get_tag.outputs.tag }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+      - 
+        name: Scan new image and output results
+        uses: Azure/container-scan@v0
+        with:
+          image-name: ${{ secrets.DOCKER_USERNAME }}/xmrblocks:${{ steps.get_tag.outputs.tag }}
+          severity-threshold: HIGH
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/update-image-on-push.yml
+++ b/.github/workflows/update-image-on-push.yml
@@ -1,0 +1,59 @@
+name: "Update image and push to Github Packages and Docker Hub when Dockerfile is changed"
+# Run this workflow every time a new commit pushed to your repository
+on:
+  push:
+    paths-ignore:
+      - 'README.md'
+jobs:
+  rebuild-container:
+    name: "Rebuild Container with the latest base image"
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.6.0
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1.10.0 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1.10.0 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: "Checkout repository"
+        uses: "actions/checkout@v2.3.4"
+      - 
+        name: "Get Monero Release Tag"
+        id: get_tag
+        run: echo "::set-output name=tag::$(awk -F "=" '/MONERO_BRANCH=/ {print $2}' Dockerfile)"
+      -
+        name: Build and push to Docker Hub and Github Packages Docker Registry
+        id: docker_build
+        uses: docker/build-push-action@v2.7.0
+        with:
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/xmrblocks:latest
+            ghcr.io/${{ github.repository_owner }}/xmrblocks:${{ steps.get_tag.outputs.tag }}
+            ${{ secrets.DOCKER_USERNAME }}/xmrblocks:latest
+            ${{ secrets.DOCKER_USERNAME }}/xmrblocks:${{ steps.get_tag.outputs.tag }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/xmrblocks:latest
+          cache-to: type=inline
+      - 
+        name: Scan new image and output results
+        uses: Azure/container-scan@v0
+        with:
+          image-name: ${{ secrets.DOCKER_USERNAME }}/xmrblocks:${{ steps.get_tag.outputs.tag }}
+          severity-threshold: HIGH
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Hi there,

This PR is very much a "use if you want, no offense if you don't" PR, but enables Docker image builds automatically:

- Weekly w/o caching to ensure all base images/packages are up to date to remediate vulns via regular updates
- When any commit is pushed, unless the commit only edits README.md

The Docker image is built and pushed to Github Packages and Docker Hub with the `latest` tag and the `MONERO_BRANCH` arg as a tag as well.

Note that for this to push to Docker Hub, you will need to create two repository secrets:

- `DOCKER_USERNAME` - your Docker Hub username
- `DOCKER_PASSWORD` - your Docker Hub password or access token

If you don't want to push to Docker Hub, I can update and remove all relevant Docker Hub configuration.

And if you don't want to build and push images at all, feel free to simply decline the PR :) The main advantage of this is users can utilize the project without needing to bother with manual builds, `git pull`'s, etc., and I will be using it to start bundling the explorer with `monerod` in a few of my projects/guides.

You can see working runs of this set of actions here:

https://github.com/sethforprivacy/onion-monero-blockchain-explorer/actions

And Docker images built using it are available here:

https://hub.docker.com/repository/docker/sethsimmons/xmrblocks