### PR TITLE
Fix Dockerfile CMD/entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ VOLUME /home/monero/.bitmonero
 # Expose default explorer http port
 EXPOSE 8081
 
-ENTRYPOINT ["/bin/sh", "-c", "./xmrblocks"]
+ENTRYPOINT ["/bin/sh", "-c"]
 
 # Set sane defaults that are overridden if the user passes any commands
-CMD ["--enable-json-api", "--enable-autorefresh-option", "--enable-emission-monitor", "--enable-pusher"]
+CMD ["./xmrblocks --enable-json-api --enable-autorefresh-option --enable-emission-monitor --enable-pusher"]

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ services:
       - xmrdata:/home/monero/.bitmonero
     ports:
       - 8081:8081
-    command: "./xmrblocks --daemon-url=monerod:18089 --enable-json-api --enable-autorefresh-option --enable-emission-monitor --enable-pusher"
+    command: ["./xmrblocks --daemon-url=monerod:18089 --enable-json-api --enable-autorefresh-option --enable-emission-monitor --enable-pusher"]
 
   volumes:
     xmrdata:

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ services:
       - xmrdata:/home/monero/.bitmonero
     ports:
       - 8081:8081
+    command: "./xmrblocks --daemon-url=monerod:18089 --enable-json-api --enable-autorefresh-option --enable-emission-monitor --enable-pusher"
 
   volumes:
     xmrdata:
@@ -301,6 +302,18 @@ alias xmrblocksmainnet='~/onion-monero-blockchain-explorer/build/xmrblocks    --
 # for testnet explorer
 alias xmrblockstestnet='~/onion-monero-blockchain-explorer/build/xmrblocks -t --port 8082 --mainnet-url "http://139.162.32.245:8081" --enable-pusher --enable-emission-monitor'
 ```
+
+Example usage when running via Docker:
+
+```bash
+# Run in foreground
+docker run -it -v <path-to-monero-blockckain-on-the-host>:/home/monero/.bitmonero -p 8081:8081  xmrblocks "./xmrblocks --daemon-url=node.sethforprivacy.com:18089 --enable-json-api --enable-autorefresh-option --enable-emission-monitor --enable-pusher"
+
+# Run in background
+docker run -it -d -v <path-to-monero-blockchain-on-the-host>:/home/monero/.bitmonero -p 8081:8081  xmrblocks "./xmrblocks --daemon-url=node.sethforprivacy.com:18089 --enable-json-api --enable-autorefresh-option --enable-emission-monitor --enable-pusher"
+```
+
+Make sure to always start the portion of command line flags with `./xmrblocks` and set any flags you would like after that, as shown above.
 
 ## Enable Monero emission
 


### PR DESCRIPTION
This PR fixes an issue with the entrypoint/CMD usage in the Dockerfile, both fixing an issue that would cause the container to not start, and allowing passing different flags to override.