### PR TITLE
Update for view tags in next hf

### DIFF
--- a/src/MempoolStatus.cpp
+++ b/src/MempoolStatus.cpp
@@ -170,7 +170,7 @@ MempoolStatus::read_mempool()
         vector<txin_to_key> input_key_imgs;
 
         // public keys and xmr amount of outputs
-        vector<pair<txout_to_key, uint64_t>> output_pub_keys;
+        vector<pair<public_key, uint64_t>> output_pub_keys;
 
         // sum xmr in inputs and ouputs in the given tx
         const array<uint64_t, 4>& sum_data = summary_of_in_out_rct(

--- a/src/MicroCore.cpp
+++ b/src/MicroCore.cpp
@@ -211,12 +211,13 @@ MicroCore::find_output_in_tx(const transaction& tx,
     auto it = std::find_if(tx.vout.begin(), tx.vout.end(),
                            [&](const tx_out& o)
                            {
-                               const txout_to_key& tx_in_to_key
-                                       = boost::get<txout_to_key>(o.target);
+                               public_key found_output_pubkey;
+                               cryptonote::get_output_public_key(
+                                    o, found_output_pubkey);
 
                                ++idx;
 
-                               return tx_in_to_key.key == output_pubkey;
+                               return found_output_pubkey == output_pubkey;
                            });
 
     if (it != tx.vout.end())

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -345,7 +345,7 @@ sum_money_in_outputs(const json& _json)
 array<uint64_t, 4>
 summary_of_in_out_rct(
         const transaction& tx,
-        vector<pair<txout_to_key, uint64_t>>& output_pub_keys,
+        vector<pair<public_key, uint64_t>>& output_pub_keys,
         vector<txin_to_key>& input_key_imgs)
 {
 
@@ -357,18 +357,15 @@ summary_of_in_out_rct(
 
     for (const tx_out& txout: tx.vout)
     {
-        if (txout.target.type() != typeid(txout_to_key))
+        public_key output_pub_key;
+        if (!cryptonote::get_output_public_key(txout, output_pub_key))
         {
             // push empty pair.
-            output_pub_keys.push_back(pair<txout_to_key, uint64_t>{});
+            output_pub_keys.push_back(pair<public_key, uint64_t>{});
             continue;
         }
 
-        // get tx input key
-        const txout_to_key& txout_key
-                = boost::get<cryptonote::txout_to_key>(txout.target);
-
-        output_pub_keys.push_back(make_pair(txout_key, txout.amount));
+        output_pub_keys.push_back(make_pair(output_pub_key, txout.amount));
 
         xmr_outputs += txout.amount;
     }
@@ -619,49 +616,43 @@ sum_fees_in_txs(const vector<transaction>& txs)
 
 
 
-vector<pair<txout_to_key, uint64_t>>
+vector<pair<public_key, uint64_t>>
 get_ouputs(const transaction& tx)
 {
-    vector<pair<txout_to_key, uint64_t>> outputs;
+    vector<pair<public_key, uint64_t>> outputs;
 
     for (const tx_out& txout: tx.vout)
     {
-        if (txout.target.type() != typeid(txout_to_key))
+        public_key output_pub_key;
+        if (!cryptonote::get_output_public_key(txout, output_pub_key))
         {
             // push empty pair.
-            outputs.push_back(pair<txout_to_key, uint64_t>{});
+            outputs.push_back(pair<public_key, uint64_t>{});
             continue;
         }
 
-        // get tx input key
-        const txout_to_key& txout_key
-                = boost::get<cryptonote::txout_to_key>(txout.target);
-
-        outputs.push_back(make_pair(txout_key, txout.amount));
+        outputs.push_back(make_pair(output_pub_key, txout.amount));
     }
 
     return outputs;
 
 };
 
-vector<tuple<txout_to_key, uint64_t, uint64_t>>
+vector<tuple<public_key, uint64_t, uint64_t>>
 get_ouputs_tuple(const transaction& tx)
 {
-    vector<tuple<txout_to_key, uint64_t, uint64_t>> outputs;
+    vector<tuple<public_key, uint64_t, uint64_t>> outputs;
 
     for (uint64_t n = 0; n < tx.vout.size(); ++n)
     {
 
-        if (tx.vout[n].target.type() != typeid(txout_to_key))
+        public_key output_pub_key;
+        if (!cryptonote::get_output_public_key(tx.vout[n], output_pub_key))
         {
             continue;
         }
 
-        // get tx input key
-        const txout_to_key& txout_key
-                = boost::get<cryptonote::txout_to_key>(tx.vout[n].target);
-
-        outputs.push_back(make_tuple(txout_key, tx.vout[n].amount, n));
+        outputs.push_back(make_tuple(output_pub_key, tx.vout[n].amount, n));
     }
 
     return outputs;
@@ -1166,11 +1157,11 @@ is_output_ours(const size_t& output_index,
     //cout << "\n" << tx.vout.size() << " " << output_index << endl;
 
     // get tx output public key
-    const txout_to_key tx_out_to_key
-            = boost::get<txout_to_key>(tx.vout[output_index].target);
+    public_key output_pub_key;
+    cryptonote::get_output_public_key(tx.vout[output_index], output_pub_key);
 
 
-    if (tx_out_to_key.key == pubkey)
+    if (output_pub_key == pubkey)
     {
         return true;
     }

--- a/src/tools.h
+++ b/src/tools.h
@@ -154,7 +154,7 @@ sum_money_in_outputs(const json& _json);
 array<uint64_t, 4>
 summary_of_in_out_rct(
         const transaction& tx,
-        vector<pair<txout_to_key, uint64_t>>& output_pub_keys,
+        vector<pair<public_key, uint64_t>>& output_pub_keys,
         vector<txin_to_key>& input_key_imgs);
 
 // this version for mempool txs from json
@@ -200,10 +200,10 @@ get_mixin_no(const json& _json);
 vector<uint64_t>
 get_mixin_no_in_txs(const vector<transaction>& txs);
 
-vector<pair<txout_to_key, uint64_t>>
+vector<pair<public_key, uint64_t>>
 get_ouputs(const transaction& tx);
 
-vector<tuple<txout_to_key, uint64_t, uint64_t>>
+vector<tuple<public_key, uint64_t, uint64_t>>
 get_ouputs_tuple(const transaction& tx);
 
 vector<txin_to_key>


### PR DESCRIPTION
At the next hard fork, wallets will construct tx's where each output has a "view tag" stored on it. It's meant to speed up wallet scanning :) More on it here: https://github.com/monero-project/monero/pull/8061

The smoothest way I could see how to add view tags to outputs in the core repo was by creating a new output type, which I called `txout_to_tagged_key` (after the fork, `txout_to_key` types won't be allowed anymore). This PR is necessary because of that change, unfortunately. To make the change as clean as I could, I added a helper function `get_output_public_key` to the core repo, so you can see in this PR the caller doesn't actually need to know the output type. I got rid of all `txout_to_key` types used in this repo and replaced with that helper function.

Hope you like! :)