### PR TITLE
css: fix overflowing text in cells

### DIFF
--- a/src/templates/css/style.css
+++ b/src/templates/css/style.css
@@ -29,6 +29,7 @@ tr, li, #pages, .info {
 
 td {
     text-align: center;
+    word-break: break-all;
 }
 
 a:link {


### PR DESCRIPTION
Long strings without spaces don't get wrapped and will result in the text overflowing outside of the cell and messing up the structure of the page. See for example [the tx_extra field in this transaction](https://xmrchain.net/search?value=1ecce7898a4e1c7334241c834ba4866d6b511ee896c318b3445aea1cc926e40f).

This small patch makes long text wrap inside the given limit, which is otherwise "ignored".