### PR TITLE
Remove --prune-blockchain from docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,6 @@ services:
       - "--public-node"
       - "--no-igd"
       - "--enable-dns-blocklist"
-      - "--prune-blockchain"
-      - "--sync-pruned-blocks"
 
   explore:
     image: xmrblocks:latest


### PR DESCRIPTION
This fixes https://github.com/moneroexamples/onion-monero-blockchain-explorer/issues/303
I'm not sure why, bit it seems onion-monero-blockchain-explorer is unable to read v2 transaction hashes when the local blockchain is pruned. The easiest fix is to not prune, so I disable it in the example.

(I'm not sure if we also want to include "--fast-block-sync=0" as default, I think it is another discussion about trust. The  "--out-peers=64" parameter is also helpful in some cases, but since I'm not quite sure what's the right number, I didn't include any of my other tweaks in this PR)