### PR TITLE
Add dependency for docker compose services

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ services:
     ports:
       - 18080:18080
       - 18089:18089
+    depends_on:
+        - explore
     command:
       - "--rpc-restricted-bind-ip=0.0.0.0"
       - "--rpc-restricted-bind-port=18089"


### PR DESCRIPTION
I know the opposite should be logical, but for some reason, this is only how it works reliably for me.

##### Why?
When I do the opposite (I set explore dependent on monerod, so docker starts monerod first), then for some reason, expore is unable to start. The logs are empty and the webpage is down. For some reason, the `explore` service can't even be restarted with `docker compose down explore`, then `docker compose up -d explore`, because it hangs just like before.

On the other hand, when I start monerod well after explore, then monerod sometimes hangs on `Loading blockchain from folder /home/monero/.bitmonero/lmdb ...`
No matter how long I wait, it's stuck and I need to force stop the service.

The only solution for me was to start monerod slightly after explore is up.

##### Future
It would be better to clean up the race condition, but after spending a day on the pruned_hash problem without a solution, I don't think I can fix it, race conditions are usually complicated.
Another great solution would be to only start the explorer when monerod is synced, so expore won't waste CPU during initial sync. Not sure how to do that, since it'd likely produce the first bug (explore hang)