### PR TITLE
bump master to v0.18.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:latest as builder
 
 # Set Monero branch/tag to be used for monerod compilation
-ARG MONERO_BRANCH=v0.18.3.4
+ARG MONERO_BRANCH=v0.18.4.0
 
 # Added DEBIAN_FRONTEND=noninteractive to workaround tzdata prompt on installation
 ENV DEBIAN_FRONTEND="noninteractive"

--- a/src/page.h
+++ b/src/page.h
@@ -2142,7 +2142,7 @@ show_my_outputs(string tx_hash_str,
     {
         cerr << "Cant get derived key for: "  << "\n"
              << "pub_tx_key: " << pub_key << " and "
-             << "prv_view_key" << prv_view_key << endl;
+             << "prv_view_key" << pod_to_hex(unwrap(unwrap(prv_view_key))) << endl;
 
         return string("Cant get key_derivation");
     }
@@ -2155,7 +2155,7 @@ show_my_outputs(string tx_hash_str,
         {
             cerr << "Cant get derived key for: "  << "\n"
                  << "pub_tx_key: " << txd.additional_pks[i] << " and "
-                 << "prv_view_key" << prv_view_key << endl;
+                 << "prv_view_key" << pod_to_hex(unwrap(unwrap(prv_view_key))) << endl;
 
             return string("Cant get key_derivation");
         }
@@ -2458,7 +2458,7 @@ show_my_outputs(string tx_hash_str,
                 {
                     cerr << "Cant get derived key for: "  << "\n"
                          << "pub_tx_key: " << mixin_tx_pub_key << " and "
-                         << "prv_view_key" << prv_view_key << endl;
+                         << "prv_view_key" << pod_to_hex(unwrap(unwrap(prv_view_key))) << endl;
 
                     continue;
                 }
@@ -2470,7 +2470,7 @@ show_my_outputs(string tx_hash_str,
                     {
                         cerr << "Cant get derived key for: "  << "\n"
                              << "pub_tx_key: " << mixin_additional_tx_pub_keys[i]
-                             << " and prv_view_key" << prv_view_key << endl;
+                             << " and prv_view_key" << pod_to_hex(unwrap(unwrap(prv_view_key))) << endl;
 
                         continue;
                     }
@@ -3186,7 +3186,7 @@ show_checkrawtx(string raw_tx_data, string action)
                 return boost::get<string>(tx_context["error_msg"]);
             }
 
-            tx_context["tx_prv_key"] =  fmt::format("{:s}", ptx.tx_key);
+            tx_context["tx_prv_key"] =  fmt::format("{:s}", pod_to_hex(unwrap(unwrap(ptx.tx_key))));
 
             mstch::array destination_addresses;
             vector<uint64_t> real_ammounts;
@@ -3737,7 +3737,7 @@ show_checkrawkeyimgs(string raw_data, string viewkey_str)
     context.insert({"address"        , REMOVE_HASH_BRAKETS(
             xmreg::print_address(address_info, nettype))});
     context.insert({"viewkey"        , REMOVE_HASH_BRAKETS(
-            fmt::format("{:s}", prv_view_key))});
+            fmt::format("{:s}", pod_to_hex(unwrap(unwrap(prv_view_key)))))});
     context.insert({"has_total_xmr"  , false});
     context.insert({"total_xmr"      , string{}});
     context.insert({"key_imgs"       , mstch::array{}});
@@ -3870,7 +3870,7 @@ show_checkcheckrawoutput(string raw_data, string viewkey_str)
 
     context.insert({"address"        , REMOVE_HASH_BRAKETS(
             xmreg::print_address(address_info, nettype))});
-    context.insert({"viewkey"        , pod_to_hex(prv_view_key)});
+    context.insert({"viewkey"        , pod_to_hex(unwrap(unwrap(prv_view_key)))});
     context.insert({"has_total_xmr"  , false});
     context.insert({"total_xmr"      , string{}});
     context.insert({"output_keys"    , mstch::array{}});
@@ -5477,7 +5477,7 @@ json_outputs(string tx_hash_str,
     // matches to what was used to produce response.
     j_data["tx_hash"]  = pod_to_hex(txd.hash);
     j_data["address"]  = pod_to_hex(address_info.address);
-    j_data["viewkey"]  = pod_to_hex(prv_view_key);
+    j_data["viewkey"]  = pod_to_hex(unwrap(unwrap(prv_view_key)));
     j_data["tx_prove"] = tx_prove;
     j_data["tx_confirmations"] = txd.no_confirmations;
     j_data["tx_timestamp"] = tx_timestamp;
@@ -5661,7 +5661,7 @@ json_outputsblocks(string _limit,
     // check if submited data in the request
     // matches to what was used to produce response.
     j_data["address"]  = pod_to_hex(address_info.address);
-    j_data["viewkey"]  = pod_to_hex(prv_view_key);
+    j_data["viewkey"]  = pod_to_hex(unwrap(unwrap(prv_view_key)));
     j_data["limit"]    = _limit;
     j_data["height"]   = height;
     j_data["mempool"]  = in_mempool_aswell;

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -1163,7 +1163,8 @@ is_output_ours(const size_t& output_index,
     {
         cerr << "Cant get dervied key for: "  << "\n"
              << "pub_tx_key: " << pub_tx_key  << " and "
-             << "prv_view_key" << private_view_key << endl;
+             << "prv_view_key" << epee::string_tools::pod_to_hex(unwrap(unwrap(private_view_key)))
+             << endl;
 
         return false;
     }


### PR DESCRIPTION
fixes build for release-v0.18 (v0.18.4.0 will be tagged soon, and will require this fix)

on another note: might be a good idea to build against tags (v0.18.4.0) instead of the branch (release-v0.18)

cherrypicked from [devel](https://github.com/moneroexamples/onion-monero-blockchain-explorer/commit/5285f9ca39d406b6de77fd9b60239ce4e5b0b4d0)