### PR TITLE
build: use v0.18.3.4 tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04 as builder
 
 # Set Monero branch/tag to be used for monerod compilation
 
-ARG MONERO_BRANCH=release-v0.18
+ARG MONERO_BRANCH=v0.18.3.4
 
 # Added DEBIAN_FRONTEND=noninteractive to workaround tzdata prompt on installation
 ENV DEBIAN_FRONTEND="noninteractive"

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Go to your browser: http://127.0.0.1:8081
 ## Compiling and running with Docker
 
 The explorer can also be compiled using `docker build` as described below. By default it compiles
-against latest release (`release-v0.17`) branch of monero:
+against latest release tag (`v0.18.3.4`) of monero:
 
 ```
 # build using all CPU cores


### PR DESCRIPTION
Build against release tag instead of release branch