### PR TITLE
Correct uid/gid for monero user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,8 @@ RUN unzip -o lib.zip \
     && apt purge -y unzip
 
 # Add user and setup directories for monerod and xmrblocks
-RUN useradd -ms /bin/bash monero \
+RUN touch /var/mail/ubuntu && chown ubuntu /var/mail/ubuntu && userdel -r ubuntu \
+    && useradd -ms /bin/bash monero \
     && mkdir -p /home/monero/.bitmonero \
     && chown -R monero:monero /home/monero/.bitmonero
 USER monero


### PR DESCRIPTION
When running this container alongside a monerod container, the mismatching UID/GID breaks permissions.

This commit resolves that by deleting the default ubuntu user (unused here) and replacing it with the newly created monero user.