### PR TITLE
Don't add libcurl as lib dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,6 @@ set(LIBRARIES
         ${Boost_LIBRARIES}
         pthread
         unbound
-        curl
         crypto
         ssl)
 


### PR DESCRIPTION
I don't know why this was done since neither Monero core nor xmrblocks needs to link against it. It just breaks builds for no reason.