### PR TITLE
MicroCore: fix segmentation fault on destructor

### DIFF
--- a/src/MicroCore.cpp
+++ b/src/MicroCore.cpp
@@ -249,21 +249,6 @@ MicroCore::get_blk_timestamp(uint64_t blk_height)
     return blk.timestamp;
 }
 
-
-/**
- * De-initialized Blockchain.
- *
- * since blockchain is opened as MDB_RDONLY
- * need to manually free memory taken on heap
- * by BlockchainLMDB
- */
-MicroCore::~MicroCore()
-{
-    //m_blockchain_storage.get_db().close();
-    delete &m_blockchain_storage.get_db();
-}
-
-
 bool
 init_blockchain(const string& path,
                 MicroCore& mcore,

--- a/src/MicroCore.h
+++ b/src/MicroCore.h
@@ -73,8 +73,6 @@ namespace xmreg
 
         hw::device* const
         get_device() const;
-
-        virtual ~MicroCore();
     };
 
 


### PR DESCRIPTION
Fixes double-free memory error bug. The underlying `cryptonote::BlockchainDB` pointer is already freed in `cryptnote::Blockchain::deinit()`, called by the destructor. Reference: https://github.com/monero-project/monero/blob/13002ddd4b1ba4b4dcd7c47aa368a87c353b2225/src/cryptonote_core/blockchain.cpp#L545.