### PR TITLE
Expose dynamic fee estimate in JSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,6 +736,8 @@ curl  -w "\n" -X GET "http://127.0.0.1:8081/api/networkinfo"
     "block_size_limit": 600000,
     "cumulative_difficulty": 2091549555696348,
     "difficulty": 7941560081,
+    "fee_estimate": 303970000,
+    "fee_estimate_grace_blocks": 10,
     "fee_per_kb": 303970000,
     "grey_peerlist_size": 4991,
     "hash_rate": 66179667,
@@ -751,6 +753,29 @@ curl  -w "\n" -X GET "http://127.0.0.1:8081/api/networkinfo"
     "tx_count": 1219048,
     "tx_pool_size": 2,
     "white_peerlist_size": 1000
+  },
+  "status": "success"
+}
+```
+
+#### api/feeestimate
+
+Current dynamic base fee estimate from the connected Monero daemon. The
+optional `grace_blocks` parameter defaults to 10.
+
+```bash
+curl  -w "\n" -X GET "http://127.0.0.1:8081/api/feeestimate"
+curl  -w "\n" -X GET "http://127.0.0.1:8081/api/feeestimate?grace_blocks=20"
+```
+
+Example result:
+
+```json
+{
+  "data": {
+    "fee": 303970000,
+    "fee_per_kb": 303970000,
+    "grace_blocks": 10
   },
   "status": "success"
 }

--- a/main.cpp
+++ b/main.cpp
@@ -753,6 +753,19 @@ main(int ac, const char* av[])
             return r;
         });
 
+        CROW_ROUTE(app, "/api/feeestimate").methods("GET"_method)
+        ([&](const crow::request &req) {
+
+            string grace_blocks = regex_search(
+                    req.raw_url, regex {"grace_blocks=\\d+"}) ?
+                                  req.url_params.get("grace_blocks") : "";
+
+            myxmr::jsonresponse r{xmrblocks.json_feeestimate(
+                    remove_bad_chars(grace_blocks))};
+
+            return r;
+        });
+
         CROW_ROUTE(app, "/api/emission")
         ([&]() {
 

--- a/src/page.h
+++ b/src/page.h
@@ -96,7 +96,7 @@ inline thread_local RandomXThreadCleanup rx_thread_cleanup;
 #define TMPL_MY_CHECKRAWOUTPUTKEYS  TMPL_DIR "/checkrawoutputkeys.html"
 
 #define ONIONEXPLORER_RPC_VERSION_MAJOR 1
-#define ONIONEXPLORER_RPC_VERSION_MINOR 2
+#define ONIONEXPLORER_RPC_VERSION_MINOR 3
 #define MAKE_ONIONEXPLORER_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define ONIONEXPLORER_RPC_VERSION \
     MAKE_ONIONEXPLORER_RPC_VERSION(ONIONEXPLORER_RPC_VERSION_MAJOR, ONIONEXPLORER_RPC_VERSION_MINOR)
@@ -5755,10 +5755,9 @@ json_networkinfo()
     //    return j_response;
     }
 
-    uint64_t fee_estimated {0};
-
     j_info["fee_per_kb"] = per_kb_fee_estimated;
-    j_info["fee_estimate"] = fee_estimated;
+    j_info["fee_estimate"] = per_kb_fee_estimated;
+    j_info["fee_estimate_grace_blocks"] = FEE_ESTIMATE_GRACE_BLOCKS;
 
     j_info["tx_pool_size"]        = MempoolStatus::mempool_no.load();
     j_info["tx_pool_size_kbytes"] = MempoolStatus::mempool_size.load();
@@ -5766,6 +5765,64 @@ json_networkinfo()
     j_data = j_info;
 
     j_response["status"]  = "success";
+
+    return j_response;
+}
+
+
+/*
+* Lets use this json api convention for success and error
+* https://labs.omniti.com/labs/jsend
+*/
+json
+json_feeestimate(string grace_blocks_str)
+{
+    json j_response {
+            {"status", "fail"},
+            {"data",   json {}}
+    };
+
+    json& j_data = j_response["data"];
+
+    uint64_t grace_blocks {FEE_ESTIMATE_GRACE_BLOCKS};
+
+    if (!grace_blocks_str.empty())
+    {
+        try
+        {
+            grace_blocks = boost::lexical_cast<uint64_t>(grace_blocks_str);
+        }
+        catch (const boost::bad_lexical_cast &e)
+        {
+            j_response["message"] = fmt::format(
+                    "Cant parse grace_blocks number: {:s}",
+                    grace_blocks_str);
+            return j_response;
+        }
+    }
+
+    uint64_t fee_estimated {0};
+    string error_msg;
+
+    if (!rpc.get_dynamic_per_kb_fee_estimate(
+            grace_blocks,
+            fee_estimated,
+            error_msg))
+    {
+        j_response["status"] = "error";
+        j_response["message"] = error_msg.empty()
+                                ? "Cant get dynamic fee estimate"
+                                : error_msg;
+        return j_response;
+    }
+
+    j_data = json {
+            {"fee", fee_estimated},
+            {"fee_per_kb", fee_estimated},
+            {"grace_blocks", grace_blocks}
+    };
+
+    j_response["status"] = "success";
 
     return j_response;
 }
@@ -7119,4 +7176,3 @@ get_tx_amount_output_indices(vector<uint64_t>& out_amount_indices, Args&&... arg
 }
 
 #endif //CROWXMR_PAGE_H
-


### PR DESCRIPTION
## Summary
- Add `GET /api/feeestimate` to return the current dynamic fee estimate from the connected Monero daemon.
- Support optional `grace_blocks`, defaulting to the existing `FEE_ESTIMATE_GRACE_BLOCKS` value.
- Populate `/api/networkinfo`'s existing `fee_estimate` field instead of returning `0`, and include the grace block window.
- Document the new endpoint and response shape.

Refs #276.

## Verification
- `git diff --check`
- `cmake -S . -B /private/tmp/moneroexplorer-fee-bounty-build` stops before compilation because the expected local Monero build tree is missing at `~/monero/build/Linux/master/release`.

If this is accepted for the 0.2 XMR bounty, I can provide a payout address.